### PR TITLE
remove all piping operators

### DIFF
--- a/docs/code/caustic_glass.jl
+++ b/docs/code/caustic_glass.jl
@@ -48,15 +48,15 @@ function render()
 
     from, to = Point3f(0, 2, 0), Point3f(-5, 0, 5)
     cone_angle, cone_δ_angle = 30f0, 10f0
-    dir = Vec3f(to - from) |> normalize
+    dir = normalize(Vec3f(to - from))
     dir, du, dv = Trace.coordinate_system(dir)
 
-    dir_to_z = Trace.Transformation(Mat4f(
+    dir_to_z = Trace.Transformation(transpose(Mat4f(
         du[1], du[2], du[3], 0f0,
         dv[1], dv[2], dv[3], 0f0,
         dir[1], dir[2], dir[3], 0f0,
         0f0, 0f0, 0f0, 1f0,
-    ) |> transpose)
+    )))
     light_to_world = (
         Trace.translate(Vec3f(4.5, 0, -101))
         * Trace.translate(Vec3f(from))
@@ -80,7 +80,7 @@ function render()
     screen = Trace.Bounds2(Point2f(-1f0), Point2f(1f0))
     filter = Trace.LanczosSincFilter(Point2f(1f0), 3f0)
 
-    ir = resolution .|> Int64
+    ir = Int64.(resolution)
     film = Trace.Film(
         resolution, Trace.Bounds2(Point2f(0), Point2f(1)),
         filter, 1f0, 1f0,
@@ -92,7 +92,7 @@ function render()
     )
 
     integrator = Trace.SPPMIntegrator(camera, 0.075f0, ray_depth, 100, -1)
-    scene |> integrator
+    integrator(scene)
 end
 
 render()

--- a/docs/code/caustic_moving.jl
+++ b/docs/code/caustic_moving.jl
@@ -53,7 +53,7 @@ function render()
     screen = Trace.Bounds2(Point2f(-1f0), Point2f(1f0))
     filter = Trace.LanczosSincFilter(Point2f(1f0), 3f0)
 
-    ir = resolution .|> Int64
+    ir = Int64.(resolution)
 
     for (i, shift) in enumerate(0:0.1:5)
         @info "Shift $shift"
@@ -61,15 +61,15 @@ function render()
         to = Point3f(-5, 0, 5)
 
         cone_angle, cone_δ_angle = 30f0, 10f0
-        dir = Vec3f(to - from) |> normalize
+        dir = normalize(Vec3f(to - from))
         dir, du, dv = Trace.coordinate_system(dir)
 
-        dir_to_z = Trace.Transformation(Mat4f(
+        dir_to_z = Trace.Transformation(transpose(Mat4f(
             du[1], du[2], du[3], 0f0,
             dv[1], dv[2], dv[3], 0f0,
             dir[1], dir[2], dir[3], 0f0,
             0f0, 0f0, 0f0, 1f0,
-        ) |> transpose)
+        )))
         light_to_world = (
             Trace.translate(Vec3f(4.5, 0, -101))
             * Trace.translate(Vec3f(from))
@@ -98,7 +98,7 @@ function render()
             screen, 0f0, 1f0, 0f0, 1f6, 90f0, film,
         )
         integrator = Trace.SPPMIntegrator(camera, 0.055f0, ray_depth, 25, 1_250_000)
-        scene |> integrator
+        integrator(scene)
     end
 end
 

--- a/docs/code/sphere.jl
+++ b/docs/code/sphere.jl
@@ -59,12 +59,12 @@ function render()
     triangle_primitive4 = Trace.GeometricPrimitive(triangles[4], material_white)
 
     bvh = Trace.BVHAccel([
-        primitive3,
-        # triangle_primitive,
-        # triangle_primitive2,
-        #triangle_primitive3,
-        triangle_primitive4,
-    ], 1)
+            primitive3,
+            # triangle_primitive,
+            # triangle_primitive2,
+            #triangle_primitive3,
+            triangle_primitive4,
+        ], 1)
 
     lights = [Trace.PointLight(
         Trace.translate(Vec3f(-1, 1, 0)), Trace.RGBSpectrum(25f0),
@@ -86,7 +86,7 @@ function render()
 
     # integrator = Trace.WhittedIntegrator(camera, Trace.UniformSampler(8), 8)
     integrator = Trace.SPPMIntegrator(camera, 0.025f0, 5, 10)
-    scene |> integrator
+    integrator(scene)
 end
 
 render()

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,30 +2,30 @@ using Documenter
 using DocumenterVitepress
 using Trace
 
-makedocs(; sitename="Trace", authors="Anton Smirnov and contributors",
-    modules=[Trace],
-    checkdocs=:all,
-    format=DocumenterVitepress.MarkdownVitepress(
+makedocs(; sitename = "Trace", authors = "Anton Smirnov and contributors",
+    modules = [Trace],
+    checkdocs = :all,
+    format = DocumenterVitepress.MarkdownVitepress(
         repo = "github.com/pxl-th/Trace.jl", # this must be the full URL!
         devbranch = "master",
         devurl = "dev";
     ),
-    draft=false,
-    source="src",
-    build= "build",
+    draft = false,
+    source = "src",
+    build = "build",
     warnonly = true,
-    pages=[
+    pages = [
         "Home" => "index.md",
         "Get Started" => "get_started.md",
         "Shadows" => "shadows.md",
-        "API" => "api.md"
+        "API" => "api.md",
     ],
-    )
+)
 
 deploydocs(;
-    repo="github.com/pxl-th/Trace.jl",
-    target="build", # this is where Vitepress stores its output
+    repo = "github.com/pxl-th/Trace.jl",
+    target = "build", # this is where Vitepress stores its output
     branch = "gh-pages",
-    devbranch="master",
-    push_preview = true
+    devbranch = "master",
+    push_preview = true,
 )

--- a/src/Trace.jl
+++ b/src/Trace.jl
@@ -20,17 +20,17 @@ abstract type Integrator end
 
 const Radiance = Val{:Radiance}
 const Importance = Val{:Importance}
-const TransportMode = Union{Radiance, Importance}
+const TransportMode = Union{Radiance,Importance}
 
 # GeometryBasics.@fixed_vector Normal StaticVector
 include("typeNormal3f.jl")
 
-const Maybe{T} = Union{T, Nothing}
+const Maybe{T} = Union{T,Nothing}
 
 function get_progress_bar(n::Integer, desc::String = "Progress")
     Progress(
-        n, desc=desc, dt=1,
-        barglyphs=BarGlyphs("[=> ]"), barlen=50, color=:white,
+        n, desc = desc, dt = 1,
+        barglyphs = BarGlyphs("[=> ]"), barlen = 50, color = :white,
     )
 end
 
@@ -48,25 +48,25 @@ function concentric_sample_disk(u::Point2f)::Point2f
         r = offset[2]
         θ = π / 2f0 - (offset[1] / offset[2]) * π / 4f0
     end
-    r * Point2f(θ |> cos, θ |> sin)
+    r * Point2f(cos(θ), sin(θ))
 end
 
 function cosine_sample_hemisphere(u::Point2f)::Vec3f
-    d = u |> concentric_sample_disk
-    z = √max(0f0, 1f0 - d[1] ^ 2 - d[2] ^ 2)
+    d = concentric_sample_disk(u)
+    z = √max(0f0, 1f0 - d[1]^2 - d[2]^2)
     Vec3f(d[1], d[2], z)
 end
 
 function uniform_sample_sphere(u::Point2f)::Vec3f
     z = 1f0 - 2f0 * u[1]
-    r = √(max(0f0, 1f0 - z ^ 2))
+    r = √(max(0f0, 1f0 - z^2))
     ϕ = 2f0 * π * u[2]
     Vec3f(r * cos(ϕ), r * sin(ϕ), z)
 end
 
 function uniform_sample_cone(u::Point2f, cosθ_max::Float32)::Vec3f
     cosθ = 1f0 - u[1] + u[1] * cosθ_max
-    sinθ = √(1f0 - cosθ ^ 2)
+    sinθ = √(1f0 - cosθ^2)
     ϕ = u[2] * 2f0 * π
     Vec3f(cos(ϕ) * sinθ, sin(ϕ) * sinθ, cosθ)
 end
@@ -75,7 +75,7 @@ function uniform_sample_cone(
     u::Point2f, cosθ_max::Float32, x::Vec3f, y::Vec3f, z::Vec3f,
 )::Vec3f
     cosθ = 1f0 - u[1] + u[1] * cosθ_max
-    sinθ = √(1f0 - cosθ ^ 2)
+    sinθ = √(1f0 - cosθ^2)
     ϕ = u[2] * 2f0 * π
     x * cos(ϕ) * sinθ + y * sin(ϕ) * sinθ + z * cosθ
 end
@@ -99,15 +99,15 @@ Since normal is `(0, 0, 1) → cos_θ = n · w = (0, 0, 1) ⋅ w = w.z`.
 """
 @inline cos_θ(w::Vec3f) = w[3]
 @inline sin_θ2(w::Vec3f) = max(0f0, 1f0 - cos_θ(w) * cos_θ(w))
-@inline sin_θ(w::Vec3f) = w |> sin_θ2 |> √
+@inline sin_θ(w::Vec3f) = √(sin_θ2(w))
 @inline tan_θ(w::Vec3f) = sin_θ(w) / cos_θ(w)
 
 @inline function cos_ϕ(w::Vec3f)
-    sinθ = w |> sin_θ
+    sinθ = sin_θ(w)
     sinθ ≈ 0f0 ? 1f0 : clamp(w[1] / sinθ, -1f0, 1f0)
 end
 @inline function sin_ϕ(w::Vec3f)
-    sinθ = w |> sin_θ
+    sinθ = sin_θ(w)
     sinθ ≈ 0f0 ? 1f0 : clamp(w[2] / sinθ, -1f0, 1f0)
 end
 
@@ -146,7 +146,7 @@ function spherical_direction(
     sin_θ * cos(ϕ) * x + sin_θ * sin(ϕ) * y + cos_θ * z
 end
 
-spherical_θ(v::Vec3f) = clamp(v[3], -1f0, 1f0) |> acos
+spherical_θ(v::Vec3f) = acos(clamp(v[3], -1f0, 1f0))
 function spherical_ϕ(v::Vec3f)
     p = atan(v[2], v[1])
     p < 0 ? p + 2f0 * π : p
@@ -165,22 +165,22 @@ include("spectrum.jl")
 include("surface_interaction.jl")
 
 struct Scene
-    lights::Vector{L} where L <: Light
-    aggregate::P where P <: Primitive
+    lights::Vector{L} where L<:Light
+    aggregate::P where P<:Primitive
     bound::Bounds3
 
     function Scene(
         lights::Vector{L}, aggregate::P,
-    ) where L <: Light where P <: Primitive
+    ) where L<:Light where P<:Primitive
         # TODO preprocess for lights
-        new(lights, aggregate, aggregate |> world_bound)
+        new(lights, aggregate, world_bound(aggregate))
     end
 end
 
-@inline function intersect!(scene::Scene, ray::Union{Ray, RayDifferentials})
+@inline function intersect!(scene::Scene, ray::Union{Ray,RayDifferentials})
     intersect!(scene.aggregate, ray)
 end
-@inline function intersect_p(scene::Scene, ray::Union{Ray, RayDifferentials})
+@inline function intersect_p(scene::Scene, ray::Union{Ray,RayDifferentials})
     intersect_p(scene.aggregate, ray)
 end
 
@@ -189,7 +189,7 @@ end
 )::Ray
     direction = p1.p - p0.p
     origin = p0.p .+ δ .* direction
-    Ray(o=origin, d=direction, time=p0.time)
+    Ray(o = origin, d = direction, time = p0.time)
 end
 @inline function spawn_ray(p0::SurfaceInteraction, p1::Interaction)::Ray
     spawn_ray(p0.core, p1)
@@ -198,7 +198,7 @@ end
     si::SurfaceInteraction, direction::Vec3f, δ::Float32 = 1f-6,
 )::Ray
     origin = si.core.p .+ δ .* direction
-    Ray(o=origin, d=direction, time=si.core.time)
+    Ray(o = origin, d = direction, time = si.core.time)
 end
 
 include("shapes/Shape.jl")

--- a/src/bounds.jl
+++ b/src/bounds.jl
@@ -16,13 +16,13 @@ Bounds3(p::Point3f) = Bounds3(p, p)
 Bounds2c(p1::Point2f, p2::Point2f) = Bounds2(min.(p1, p2), max.(p1, p2))
 Bounds3c(p1::Point3f, p2::Point3f) = Bounds3(min.(p1, p2), max.(p1, p2))
 
-function Base.:(==)(b1::Union{Bounds2, Bounds3}, b2::Union{Bounds2, Bounds3})
+function Base.:(==)(b1::Union{Bounds2,Bounds3}, b2::Union{Bounds2,Bounds3})
     b1.p_min == b2.p_min && b1.p_max == b2.p_max
 end
-function Base.:≈(b1::Union{Bounds2, Bounds3}, b2::Union{Bounds2, Bounds3})
+function Base.:≈(b1::Union{Bounds2,Bounds3}, b2::Union{Bounds2,Bounds3})
     b1.p_min ≈ b2.p_min && b1.p_max ≈ b2.p_max
 end
-function Base.getindex(b::Union{Bounds2, Bounds3}, i::Integer)
+function Base.getindex(b::Union{Bounds2,Bounds3}, i::Integer)
     i == 1 && return b.p_min
     i == 2 && return b.p_max
     error("Invalid index `$i`. Only `1` & `2` are valid.")
@@ -38,7 +38,7 @@ end
 
 function Base.iterate(
     b::Bounds2, i::Integer = 1,
-)::Union{Nothing, Tuple{Point2f, Integer}}
+)::Union{Nothing,Tuple{Point2f,Integer}}
     i > length(b) && return nothing
 
     j = i - 1
@@ -50,17 +50,17 @@ end
 function corner(b::Bounds3, c::Integer)
     c -= 1
     Point3f(
-        b[(c & 1) + 1][1],
+        b[(c&1)+1][1],
         b[(c & 2) != 0 ? 2 : 1][2],
         b[(c & 4) != 0 ? 2 : 1][3],
     )
 end
 
-function Base.union(b1::B, b2::B) where B <: Union{Bounds2, Bounds3}
+function Base.union(b1::B, b2::B) where B<:Union{Bounds2,Bounds3}
     B(min.(b1.p_min, b2.p_min), max.(b1.p_max, b2.p_max))
 end
 
-function Base.intersect(b1::B, b2::B) where B <: Union{Bounds2, Bounds3}
+function Base.intersect(b1::B, b2::B) where B<:Union{Bounds2,Bounds3}
     B(max.(b1.p_min, b2.p_min), min.(b1.p_max, b2.p_max))
 end
 
@@ -77,10 +77,10 @@ function inside_exclusive(b::Bounds3, p::Point3f)
 end
 
 expand(b::Bounds3, δ::Float32) = Bounds3(b.p_min .- δ, b.p_max .+ δ)
-diagonal(b::Union{Bounds2, Bounds3}) = b.p_max - b.p_min
+diagonal(b::Union{Bounds2,Bounds3}) = b.p_max - b.p_min
 
 function surface_area(b::Bounds3)
-    d = b |> diagonal
+    d = diagonal(b)
     2 * (d[1] * d[2] + d[1] * d[3] + d[2] * d[3])
 end
 
@@ -89,16 +89,16 @@ function area(b::Bounds2)
     δ[1] * δ[2]
 end
 
-@inline function sides(b::Union{Bounds2, Bounds3})
+@inline function sides(b::Union{Bounds2,Bounds3})
     [abs(b1 - b0) for (b1, b0) in zip(b.p_max, b.p_min)]
 end
 
-@inline function inclusive_sides(b::Union{Bounds2, Bounds3})
+@inline function inclusive_sides(b::Union{Bounds2,Bounds3})
     [abs(b1 - (b0 - 1f0)) for (b1, b0) in zip(b.p_max, b.p_min)]
 end
 
 function volume(b::Bounds3)
-    d = b |> diagonal
+    d = diagonal(b)
     d[1] * d[2] * d[3]
 end
 
@@ -110,7 +110,7 @@ when building ray-tracing acceleration structures.
 1 - x, 2 - y, 3 - z.
 """
 function maximum_extent(b::Bounds3)
-    d = b |> diagonal
+    d = diagonal(b)
     if d[1] > d[2] && d[1] > d[3]
         return 1
     elseif d[2] > d[3]
@@ -142,13 +142,13 @@ function offset(b::Bounds3, p::Point3f)
     )
 end
 
-function bounding_sphere(b::Bounds3)::Tuple{Point3f, Float32}
+function bounding_sphere(b::Bounds3)::Tuple{Point3f,Float32}
     center = (b.p_min + b.p_max) / 2f0
     radius = inside(b, center) ? distance(center, b.p_max) : 0f0
     center, radius
 end
 
-function intersect(b::Bounds3, ray::AbstractRay)::Tuple{Bool, Float32, Float32}
+function intersect(b::Bounds3, ray::AbstractRay)::Tuple{Bool,Float32,Float32}
     t0, t1 = 0f0, ray.t_max
     @inbounds for i in 1:3
         # Update interval for i-th bbox slab.
@@ -182,19 +182,19 @@ function intersect_p(
     inv_dir::Vec3f, dir_is_negative::Point3{UInt8},
 )::Bool
     tx_min = (b[dir_is_negative[1]][1] - ray.o[1]) * inv_dir[1]
-    tx_max = (b[3 - dir_is_negative[1]][1] - ray.o[1]) * inv_dir[1]
+    tx_max = (b[3-dir_is_negative[1]][1] - ray.o[1]) * inv_dir[1]
     ty_min = (b[dir_is_negative[2]][2] - ray.o[2]) * inv_dir[2]
-    ty_max = (b[3 - dir_is_negative[2]][2] - ray.o[2]) * inv_dir[2]
+    ty_max = (b[3-dir_is_negative[2]][2] - ray.o[2]) * inv_dir[2]
 
     (tx_min > ty_max || ty_min > tx_max) && return false
-    ty_min > tx_min && (tx_min = ty_min;)
-    ty_max > tx_max && (tx_max = ty_max;)
+    ty_min > tx_min && (tx_min = ty_min)
+    ty_max > tx_max && (tx_max = ty_max)
 
     tz_min = (b[dir_is_negative[3]][3] - ray.o[3]) * inv_dir[3]
-    tz_max = (b[3 - dir_is_negative[3]][3] - ray.o[3]) * inv_dir[3]
+    tz_max = (b[3-dir_is_negative[3]][3] - ray.o[3]) * inv_dir[3]
     (tx_min > tz_max || tz_min > tx_max) && return false
 
-    (tz_min > tx_min) && (tx_min = tz_min;)
-    (tz_max < tx_max) && (tx_max = tz_max;)
+    (tz_min > tx_min) && (tx_min = tz_min)
+    (tz_max < tx_max) && (tx_max = tz_max)
     tx_min < ray.t_max && tx_max > 0
 end

--- a/src/camera/camera.jl
+++ b/src/camera/camera.jl
@@ -38,7 +38,7 @@ based on their optical properties.
 """
 function generate_ray(
     camera::C, sample::CameraSample,
-)::Tuple{Ray, Float32} where C <: Camera
+)::Tuple{Ray,Float32} where C<:Camera
 end
 """
 Same as `generate_ray`, but also computes rays for pixels shifted one pixel
@@ -47,7 +47,7 @@ Useful for anti-aliasing textures.
 """
 function generate_ray_differential(
     camera::C, sample::CameraSample,
-)::Tuple{RayDifferentials, Float32} where C <: Camera
+)::Tuple{RayDifferentials,Float32} where C<:Camera
     ray, wt = generate_ray(camera, sample)
     shifted_x = CameraSample(
         sample.film + Point2f(1f0, 0f0), sample.lens, sample.time,

--- a/src/film.jl
+++ b/src/film.jl
@@ -12,7 +12,7 @@ struct Film
     """
     crop_bounds::Bounds2
     diagonal::Float32
-    filter::F where F <: Filter
+    filter::F where F<:Filter
     filename::String
     """
     pixels in (y, x) format
@@ -34,7 +34,7 @@ struct Film
     function Film(
         resolution::Point2f, crop_bounds::Bounds2, filter::F,
         diagonal::Float32, scale::Float32, filename::String,
-    ) where F <: Filter
+    ) where F<:Filter
         filter_table_width = 16
         filter_table = Matrix{Float32}(undef, filter_table_width, filter_table_width)
         # Compute film image bounds.
@@ -42,7 +42,7 @@ struct Film
             ceil.(resolution .* crop_bounds.p_min) .+ 1f0,
             ceil.(resolution .* crop_bounds.p_max),
         )
-        crop_resolution = crop_bounds |> inclusive_sides .|> Int32
+        crop_resolution = Int32.(inclusive_sides(crop_bounds))
         # Allocate film image storage.
         pixels = Pixel[
             Pixel(Point3f(0f0), 0f0, Point3f(0f0))
@@ -50,9 +50,9 @@ struct Film
         ]
         # Precompute filter weight table.
         r = filter.radius ./ filter_table_width
-        for y in 0:filter_table_width - 1, x in 0:filter_table_width - 1
+        for y in 0:filter_table_width-1, x in 0:filter_table_width-1
             p = Point2f((x + 0.5f0) * r[1], (y + 0.5f0) * r[2])
-            filter_table[y + 1, x + 1] = p |> filter
+            filter_table[y+1, x+1] = filter(p)
         end
         new(
             resolution, crop_bounds, diagonal * 0.001f0, filter, filename,
@@ -78,13 +78,13 @@ This is needed for realistic cameras.
 """
 function get_physical_extension(f::Film)
     aspect = f.resolution[2] / f.resolution[1]
-    x = sqrt(f.diagonal ^ 2 / (1 + aspect ^ 2))
+    x = sqrt(f.diagonal^2 / (1 + aspect^2))
     y = aspect * x
     Bounds2(Point2f(-x / 2f0, -y / 2f0), Point2f(x / 2f0, y / 2f0))
 end
 
 mutable struct FilmTilePixel
-    contrib_sum::S where S <: Spectrum
+    contrib_sum::S where S<:Spectrum
     filter_weight_sum::Float32
 end
 FilmTilePixel() = FilmTilePixel(RGBSpectrum(), 0f0)
@@ -104,7 +104,7 @@ struct FilmTile
         bounds::Bounds2, filter_radius::Point2f,
         filter_table::Matrix{Float32}, filter_table_width::Int32,
     )
-        tile_res = (bounds |> inclusive_sides .|> Int32)
+        tile_res = (Int32.(inclusive_sides(bounds)))
         pixels = [FilmTilePixel() for _ in 1:tile_res[2], __ in 1:tile_res[1]]
         new(
             bounds, filter_radius, 1f0 ./ filter_radius,
@@ -134,7 +134,7 @@ Add sample contribution to the film tile.
 function add_sample!(
     t::FilmTile, point::Point2f, spectrum::S,
     sample_weight::Float32 = 1f0,
-) where S <: Spectrum
+) where S<:Spectrum
     # Compute sample's raster bounds.
     discrete_point = point .- 0.5f0
     p0 = ceil.(discrete_point .- t.filter_radius)
@@ -146,11 +146,11 @@ function add_sample!(
     offsets_y = Vector{Int32}(undef, Int32(p1[2] - p0[2] + 1))
     for (i, x) in enumerate(p0[1]:p1[1])
         fx = abs((x - discrete_point[1]) * t.inv_filter_radius[1] * t.filter_table_width)
-        offsets_x[i] = clamp(fx |> ceil, 1, t.filter_table_width)  # TODO is clipping ok?
+        offsets_x[i] = clamp(ceil(fx), 1, t.filter_table_width)  # TODO is clipping ok?
     end
     for (i, y) in enumerate(p0[2]:p1[2])
         fy = abs((y - discrete_point[2]) * t.inv_filter_radius[2] * t.filter_table_width)
-        offsets_y[i] = clamp(fy |> floor, 1, t.filter_table_width)
+        offsets_y[i] = clamp(floor(fy), 1, t.filter_table_width)
     end
     # Loop over filter support & add sample to pixel array.
     for (j, y) in enumerate(p0[2]:p1[2]), (i, x) in enumerate(p0[1]:p1[1])
@@ -167,7 +167,7 @@ end
 Point in (x, y) format.
 """
 @inline function get_pixel(t::FilmTile, p::Point2f)
-    pp = (p .- t.bounds.p_min .+ 1f0) .|> Int32
+    pp = Int32.((p .- t.bounds.p_min .+ 1f0))
     t.pixels[pp[2], pp[1]]
 end
 
@@ -175,7 +175,7 @@ end
 Point in (x, y) format.
 """
 @inline function get_pixel(f::Film, p::Point2f)
-    pp = (p .- f.crop_bounds.p_min .+ 1f0) .|> Int32
+    pp = Int32.((p .- f.crop_bounds.p_min .+ 1f0))
     f.pixels[pp[2], pp[1]]
 end
 
@@ -187,15 +187,15 @@ function merge_film_tile!(f::Film, ft::FilmTile)
         pixel = Point2f(x, y)
         tile_pixel = get_pixel(ft, pixel)
         merge_pixel = get_pixel(f, pixel)
-        merge_pixel.xyz += tile_pixel.contrib_sum |> to_XYZ
+        merge_pixel.xyz += to_XYZ(tile_pixel.contrib_sum)
         merge_pixel.filter_weight_sum += tile_pixel.filter_weight_sum
     end
 end
 
-function set_image!(f::Film, spectrum::Matrix{S}) where S <: Spectrum
+function set_image!(f::Film, spectrum::Matrix{S}) where S<:Spectrum
     @assert size(f.pixels) == size(spectrum)
     for (i, p) in enumerate(f.pixels)
-        p.xyz = spectrum[i] |> to_XYZ
+        p.xyz = to_XYZ(spectrum[i])
         p.filter_weight_sum = 1f0
         p.splat_xyz = Point3f(0f0)
     end

--- a/src/filter.jl
+++ b/src/filter.jl
@@ -10,14 +10,14 @@ function (f::LanczosSincFilter)(p::Point2f)::Float32
 end
 
 @inline function sinc(x::Float32)::Float32
-    x = x |> abs
+    x = abs(x)
     x < 1f-5 && return 1f0
-    x *= π |> Float32
+    x *= Float32(π)
     sin(x) / x
 end
 
 function windowed_sinc(x::Float32, r::Float32, τ::Float32)::Float32
-    x = x |> abs
+    x = abs(x)
     x > r && return 0f0
     sinc(x) * sinc(x / τ)
 end

--- a/src/integrators/sppm.jl
+++ b/src/integrators/sppm.jl
@@ -88,7 +88,7 @@ mutable struct SPPMPixel
         ϕ::AtomicVec3f = AtomicVec3f(0f0),
         τ::RGBSpectrum = RGBSpectrum(0f0),
         radius::Float32 = 0f0, M::Int64 = 0, N::Int64 = 0,
-        vp::VisiblePoint = VisiblePoint()
+        vp::VisiblePoint = VisiblePoint(),
     )
         new(Ld, ϕ, τ, radius, Threads.Atomic{Int64}(M), N, vp)
     end
@@ -106,7 +106,7 @@ mutable struct SPPMPixelListNode
 end
 
 struct SPPMIntegrator <: Integrator
-    camera::C where C <: Camera
+    camera::C where C<:Camera
     initial_search_radius::Float32
     max_depth::Int64
     n_iterations::Int64
@@ -117,7 +117,7 @@ struct SPPMIntegrator <: Integrator
         camera::C, initial_search_radius::Float32, max_depth::Int64,
         n_iterations::Int64, photons_per_iteration::Int64 = -1,
         write_frequency::Int64 = 1,
-    ) where C <: Camera
+    ) where C<:Camera
         photons_per_iteration = (
             photons_per_iteration > 0
             ? photons_per_iteration : area(get_film(camera).crop_bounds)
@@ -132,20 +132,20 @@ end
 function (i::SPPMIntegrator)(scene::Scene)
     pixel_bounds = get_film(i.camera).crop_bounds
 
-    b_sides = pixel_bounds |> inclusive_sides
+    b_sides = inclusive_sides(pixel_bounds)
     n_pixels = UInt64(b_sides[1] * b_sides[2])
     pixels = [
-        SPPMPixel(radius=i.initial_search_radius)
+        SPPMPixel(radius = i.initial_search_radius)
         for y in 1:b_sides[2], x in 1:b_sides[1]
     ]
     grid = Maybe{SPPMPixelListNode}[nothing for _ in 1:n_pixels]
 
     γ = 2f0 / 3f0
-    inv_sqrt_spp = 1f0 / sqrt(i.n_iterations) |> Float32
-    light_distribution = scene |> compute_light_power_distribution
+    inv_sqrt_spp = Float32(1f0 / sqrt(i.n_iterations))
+    light_distribution = compute_light_power_distribution(scene)
 
     tile_size = 16
-    pixel_extent = pixel_bounds |> diagonal
+    pixel_extent = diagonal(pixel_bounds)
     n_tiles::Point2 = Int64.(floor.((pixel_extent .+ tile_size) ./ tile_size))
 
     sampler = UniformSampler(1)
@@ -155,7 +155,7 @@ function (i::SPPMIntegrator)(scene::Scene)
             n_tiles, tile_size, sampler,
             pixel_bounds, inv_sqrt_spp,
         )
-        grid |> _clean_grid!
+        _clean_grid!(grid)
         grid_bounds, grid_resolution = _populate_grid!(grid, pixels)
         _trace_photons!(
             i, scene, iteration, light_distribution,
@@ -166,8 +166,8 @@ function (i::SPPMIntegrator)(scene::Scene)
         # Periodically store SPPM image in film and save it.
         if iteration % i.write_frequency == 0 || iteration == i.n_iterations
             image = _sppm_to_image(i, pixels, iteration)
-            set_image!(i.camera |> get_film, image)
-            i.camera |> get_film |> save
+            set_image!(get_film(i.camera), image)
+            save(get_film(i.camera))
         end
     end
 end
@@ -176,7 +176,7 @@ function _generate_visible_sppm_points!(
     i::SPPMIntegrator, pixels::Matrix{SPPMPixel}, scene::Scene,
     n_tiles::Point2, tile_size::Int64, sampler::S,
     pixel_bounds::Bounds2, inv_sqrt_spp::Float32,
-) where S <: AbstractSampler
+) where S<:AbstractSampler
     width, height = n_tiles
     total_tiles = width * height - 1
 
@@ -184,7 +184,7 @@ function _generate_visible_sppm_points!(
     Threads.@threads for k in 0:total_tiles
         x, y = k % width, k ÷ width
         tile = Point2f(x, y)
-        tile_sampler = sampler |> deepcopy
+        tile_sampler = deepcopy(sampler)
 
         tb_min = pixel_bounds.p_min .+ tile .* tile_size
         tb_max = min.(tb_min .+ (tile_size - 1), pixel_bounds.p_max)
@@ -196,12 +196,12 @@ function _generate_visible_sppm_points!(
             camera_sample = get_camera_sample(tile_sampler, pixel_point)
             ray, β = generate_ray_differential(i.camera, camera_sample)
             β ≈ 0f0 && continue
-            β = β |> RGBSpectrum
+            β = RGBSpectrum(β)
             @assert !isnan(β)
             scale_differentials!(ray, inv_sqrt_spp)
             # Follow camera ray path until a visible point is created.
             # Get SPPMPixel for current `pixel`.
-            pixel_point = pixel_point .|> Int64
+            pixel_point = Int64.(pixel_point)
             pixel = pixels[pixel_point[2], pixel_point[1]]
             specular_bounce = false
             depth = 1
@@ -234,12 +234,12 @@ function _generate_visible_sppm_points!(
                     BSDF_DIFFUSE | BSDF_REFLECTION | BSDF_TRANSMISSION,
                 ) > 0
                 is_glossy = num_components(surface_interaction.bsdf,
-                    BSDF_GLOSSY | BSDF_REFLECTION | BSDF_TRANSMISSION
+                    BSDF_GLOSSY | BSDF_REFLECTION | BSDF_TRANSMISSION,
                 ) > 0
                 if is_diffuse || (is_glossy && depth == i.max_depth)
                     pixel.vp = VisiblePoint(
-                        p=surface_interaction.core.p, wo=wo,
-                        bsdf=surface_interaction.bsdf, β=β,
+                        p = surface_interaction.core.p, wo = wo,
+                        bsdf = surface_interaction.bsdf, β = β,
                     )
                     break
                 end
@@ -248,24 +248,24 @@ function _generate_visible_sppm_points!(
                 # Spawn ray from SPPM camera path vertex.
                 wi, f, pdf, sampled_type = sample_f(
                     surface_interaction.bsdf, wo,
-                    tile_sampler |> get_2d, BSDF_ALL,
+                    get_2d(tile_sampler), BSDF_ALL,
                 )
                 (pdf ≈ 0f0 || is_black(f)) && break
                 specular_bounce = (sampled_type & BSDF_SPECULAR) != 0
                 β *= f * abs(wi ⋅ surface_interaction.shading.n) / pdf
                 @assert !isnan(β)
-                βy = β |> to_Y
+                βy = to_Y(β)
                 if βy < 0.25f0
                     continue_probability = min(1f0, βy)
                     get_1d(tile_sampler) > continue_probability && break
                     β /= continue_probability
                     @assert !isnan(β) && !isinf(β)
                 end
-                ray = spawn_ray(surface_interaction, wi) |> RayDifferentials
+                ray = RayDifferentials(spawn_ray(surface_interaction, wi))
                 depth += 1
             end
         end
-        bar |> next!
+        next!(bar)
     end
 end
 
@@ -278,7 +278,7 @@ end
 function _populate_grid!(
     grid::Vector{Maybe{SPPMPixelListNode}}, pixels::Matrix{SPPMPixel},
 )
-    n_pixels = pixels |> length |> UInt64
+    n_pixels = UInt64(length(pixels))
     # Create grid of all SPPM visible points.
     grid_bounds = Bounds3()
     # Compute grid bounds for SPPM visible points.
@@ -290,8 +290,8 @@ function _populate_grid!(
         min_radius = min(min_radius, pixel.radius)
     end
     # Compute resolution of SPPM grid in each dimension.
-    diag = grid_bounds |> diagonal
-    max_diag = diag |> maximum
+    diag = diagonal(grid_bounds)
+    max_diag = maximum(diag)
     # TODO can be inf if no visible points
     @assert max_diag > 0
     @assert !isinf(max_radius)
@@ -329,7 +329,7 @@ function _trace_photons!(
     bar = get_progress_bar(
         i.photons_per_iteration, "[$iteration] Photon pass: ",
     )
-    Threads.@threads for photon_index in 0:i.photons_per_iteration - 1
+    Threads.@threads for photon_index in 0:i.photons_per_iteration-1
         # Follow photon path for `photon_index`.
         halton_index = halton_base + photon_index
         halton_dim = 0
@@ -360,12 +360,12 @@ function _trace_photons!(
             light, u_light_0, u_light_1, u_light_time,
         )
         (pdf_pos ≈ 0f0 || pdf_dir ≈ 0f0 || is_black(le)) && continue
-        photon_ray = ray |> RayDifferentials
+        photon_ray = RayDifferentials(ray)
         β = abs(light_normal ⋅ photon_ray.d) * le / (
             light_pdf * pdf_pos * pdf_dir
         )
         is_black(β) && continue
-        βy = β |> to_Y
+        βy = to_Y(β)
 
         # Follow photon path through scene and record intersections.
         depth = 1
@@ -384,7 +384,7 @@ function _trace_photons!(
                     while node ≢ nothing
                         if distance_squared(
                             node.pixel.vp.p, interaction.core.p,
-                        ) > (node.pixel.radius ^ 2)
+                        ) > (node.pixel.radius^2)
                             node = node.next
                             continue
                         end
@@ -426,10 +426,10 @@ function _trace_photons!(
             end
             halton_dim += 1
             # β = β_new / (1f0 - q)
-            photon_ray = spawn_ray(interaction, wi) |> RayDifferentials
+            photon_ray = RayDifferentials(spawn_ray(interaction, wi))
             depth += 1
         end
-        bar |> next!
+        next!(bar)
     end
 end
 
@@ -442,7 +442,7 @@ function _update_pixels!(pixels::Matrix{SPPMPixel}, γ::Float32)
             # Update pixel photon count, search radius and τ from photons.
             N_new = pixel.N + γ * M
             radius_new = pixel.radius * √(N_new / (pixel.N + M))
-            pixel.τ = (pixel.τ + ϕ) * (radius_new / pixel.radius) ^ 2
+            pixel.τ = (pixel.τ + ϕ) * (radius_new / pixel.radius)^2
             # TODO do not multiply by beta?
             # (pixel.τ + pixel.vp.β * pixel.ϕ)
 
@@ -461,10 +461,10 @@ function _sppm_to_image(
 )
     @assert iteration > 0
     Np = iteration * i.photons_per_iteration * π
-    image = fill(RGBSpectrum(0f0), pixels |> size)
+    image = fill(RGBSpectrum(0f0), size(pixels))
     @inbounds for (i, p) in enumerate(pixels)
         # Combine direct and indirect radiance estimates.
-        image[i] = (p.Ld / iteration) + (p.τ / (Np * (p.radius ^ 2)))
+        image[i] = (p.Ld / iteration) + (p.τ / (Np * (p.radius^2)))
     end
     image
 end
@@ -476,7 +476,7 @@ Computed indices are in [0, resolution), which is the correct input for `hash`.
 """
 @inline function to_grid(
     p::Point3f, bounds::Bounds3, grid_resolution::Point3,
-)::Tuple{Bool, Point3{UInt64}}
+)::Tuple{Bool,Point3{UInt64}}
     p_offset = offset(bounds, p)
     grid_point = Point3{Int64}(
         floor(grid_resolution[1] * p_offset[1]),
@@ -500,16 +500,16 @@ end
 
 function uniform_sample_one_light(
     i::SurfaceInteraction, scene::Scene, sampler::S,
-)::RGBSpectrum where S <: AbstractSampler
-    n_lights = scene.lights |> length
+)::RGBSpectrum where S<:AbstractSampler
+    n_lights = length(scene.lights)
     n_lights == 0 && return RGBSpectrum(0f0)
 
     light_num = max(1, min(Int32(ceil(get_1d(sampler) * n_lights)), n_lights))
     light_pdf = 1f0 / n_lights
 
     light = scene.lights[light_num]
-    u_light = sampler |> get_2d
-    u_scatter = sampler |> get_2d
+    u_light = get_2d(sampler)
+    u_scatter = get_2d(sampler)
 
     estimate_direct(i, u_scatter, light, u_light, scene, sampler) / light_pdf
 end
@@ -517,7 +517,7 @@ end
 function estimate_direct(
     interaction::SurfaceInteraction, u_scatter::Point2f, light::L,
     u_light::Point2f, scene::Scene, sampler::S, specular::Bool = false,
-)::RGBSpectrum where {L <: Light, S <: AbstractSampler}
+)::RGBSpectrum where {L<:Light,S<:AbstractSampler}
     bsdf_flags = specular ? BSDF_ALL : (BSDF_ALL & ~BSDF_SPECULAR)
     Ld = RGBSpectrum(0f0)
     # Sample light source with multiple importance sampling.
@@ -526,11 +526,12 @@ function estimate_direct(
         # Evaluate BSDF for light sampling strategy.
         f = (
             interaction.bsdf(interaction.core.wo, wi, bsdf_flags)
-            * abs(wi ⋅ interaction.shading.n)
+            *
+            abs(wi ⋅ interaction.shading.n)
         )
         if !is_black(f)
             # Compute effect of visibility for light source sample.
-            !unoccluded(visibility, scene) && (Li = RGBSpectrum(0f0);)
+            !unoccluded(visibility, scene) && (Li = RGBSpectrum(0f0))
             if !is_black(Li)
                 if is_δ_light(light.flags)
                     Ld += f * Li / light_pdf
@@ -553,8 +554,8 @@ end
 @inline function power_heuristic(
     nf::Int64, f_pdf::Float32, ng::Int64, g_pdf::Float32,
 )
-    f = (nf * f_pdf) ^ 2
-    g = (ng * g_pdf) ^ 2
+    f = (nf * f_pdf)^2
+    g = (ng * g_pdf)^2
     f / (f + g)
 end
 
@@ -562,5 +563,5 @@ end
     scene::Scene,
 )::Maybe{Distribution1D}
     length(scene.lights) == 0 && return nothing
-    Distribution1D([(l |> power |> to_Y) for l in scene.lights])
+    Distribution1D([(to_Y(power(l))) for l in scene.lights])
 end

--- a/src/lights/directional.jl
+++ b/src/lights/directional.jl
@@ -3,7 +3,7 @@ Directional light does not take medium interface, since only reasonable
 interface for it is vacuum, otherwise all the light would've been absorbed
 by the medium, since the light is infinitely far away.
 """
-mutable struct DirectionalLight{S <: Spectrum} <: Light
+mutable struct DirectionalLight{S<:Spectrum} <: Light
     """
     Since directional lights represent singularities that emit light
     along a single direction, flag is set to `LightδDirection`.
@@ -23,22 +23,22 @@ mutable struct DirectionalLight{S <: Spectrum} <: Light
 
     function DirectionalLight(
         light_to_world::Transformation, l::S, direction::Vec3f,
-    ) where S <: Spectrum
+    ) where S<:Spectrum
         new{S}(
-            LightδDirection, light_to_world, light_to_world |> inv,
-            l, direction |> light_to_world |> normalize,
+            LightδDirection, light_to_world, inv(light_to_world),
+            l, normalize(light_to_world(direction)),
             0f0, Point3f(0f0), # To be computed in preprocessing stage.
         )
     end
 end
 
 @inline function preprocess!(d::DirectionalLight, scene::Scene)
-    d.world_center, d.world_radius = scene.bound |> bounding_sphere
+    d.world_center, d.world_radius = bounding_sphere(scene.bound)
 end
 
 function sample_li(
     d::DirectionalLight{S}, ref::Interaction, u::Point2f,
-)::Tuple{S, Vec3f, Float32, VisibilityTester} where S <: Spectrum
+)::Tuple{S,Vec3f,Float32,VisibilityTester} where S<:Spectrum
     outside_point = ref.p .+ d.direction .* (2 * d.world_radius)
     tester = VisibilityTester(
         ref, Interaction(outside_point, ref.time, Vec3f(0f0), Normal3f(0f0)),
@@ -51,6 +51,6 @@ The total power emitted by the directional light is related to the
 spatial extent of the scene and equals the amount of power arriving at the
 inscribed by bounding sphere disk: `I * π * r^2`.
 """
-@inline function power(d::DirectionalLight{S})::S where S <: Spectrum
-    d.i * π * d.world_radius ^ 2
+@inline function power(d::DirectionalLight{S})::S where S<:Spectrum
+    d.i * π * d.world_radius^2
 end

--- a/src/lights/emission.jl
+++ b/src/lights/emission.jl
@@ -16,7 +16,7 @@ function blackbody!(Le::Vector{Float32}, λ::Vector{Float32}, T::Float32)
     for i in 1:length(λ)
         # Compute emmited radiance for blackbody at wavelength λi.
         l = λ[i] * 1f-9 # Convert nanometers to meters.
-        Le[i] = (2 * ℎ * c * c) / (l ^ 5 * (exp((ℎ * c) / (l * kb * T)) - 1f0))
+        Le[i] = (2 * ℎ * c * c) / (l^5 * (exp((ℎ * c) / (l * kb * T)) - 1f0))
     end
 end
 """

--- a/src/lights/light.jl
+++ b/src/lights/light.jl
@@ -1,8 +1,8 @@
 @enum LightFlags::UInt8 begin
-    LightδPosition  = 0b1
+    LightδPosition = 0b1
     LightδDirection = 0b10
-    LightArea       = 0b100
-    LightInfinite   = 0b1000
+    LightArea = 0b100
+    LightInfinite = 0b1000
 end
 
 @inline function is_δ_light(flag::LightFlags)::Bool
@@ -38,4 +38,4 @@ end
 Emmited light if ray hit an area light source.
 By default light sources have no area.
 """
-@inline le(::Light, ::Union{Ray, RayDifferentials}) = RGBSpectrum(0f0)
+@inline le(::Light, ::Union{Ray,RayDifferentials}) = RGBSpectrum(0f0)

--- a/src/lights/point.jl
+++ b/src/lights/point.jl
@@ -1,4 +1,4 @@
-struct PointLight{S <: Spectrum} <: Light
+struct PointLight{S<:Spectrum} <: Light
     """
     Since point lights represent singularities that only emit light
     from a single position, flag is set to `LightδPosition`.
@@ -16,10 +16,10 @@ struct PointLight{S <: Spectrum} <: Light
     """
     position::Point3f
 
-    function PointLight(light_to_world::Transformation, i::S) where S <: Spectrum
+    function PointLight(light_to_world::Transformation, i::S) where S<:Spectrum
         new{S}(
-            LightδPosition, light_to_world, light_to_world |> inv,
-            i, Point3f(0f0) |> light_to_world,
+            LightδPosition, light_to_world, inv(light_to_world),
+            i, light_to_world(Point3f(0f0)),
         )
     end
 end
@@ -48,7 +48,7 @@ due to that light, assuming there are no occluding objects between them.
         there are no occluding objects between the light and reference point.
 """
 function sample_li(p::PointLight, ref::Interaction, ::Point2f)
-    wi = Vec3f(p.position - ref.p) |> normalize
+    wi = normalize(Vec3f(p.position - ref.p))
     pdf = 1f0
     visibility = VisibilityTester(
         ref, Interaction(p.position, ref.time, Vec3f(0f0), Normal3f(0f0)),
@@ -59,10 +59,10 @@ end
 
 function sample_le(
     p::PointLight, u1::Point2f, ::Point2f, ::Float32,
-)::Tuple{RGBSpectrum, Ray, Normal3f, Float32, Float32}
-    ray = Ray(o=p.position, d=uniform_sample_sphere(u1))
+)::Tuple{RGBSpectrum,Ray,Normal3f,Float32,Float32}
+    ray = Ray(o = p.position, d = uniform_sample_sphere(u1))
     @assert norm(ray.d) ≈ 1f0
-    light_normal = ray.d |> Normal3f
+    light_normal = Normal3f(ray.d)
     pdf_pos = 1f0
     pdf_dir = uniform_sphere_pdf()
     p.i, ray, light_normal, pdf_pos, pdf_dir

--- a/src/lights/spot.jl
+++ b/src/lights/spot.jl
@@ -1,4 +1,4 @@
-struct SpotLight{S <: Spectrum} <: Light
+struct SpotLight{S<:Spectrum} <: Light
     flags::LightFlags
     light_to_world::Transformation
     world_to_light::Transformation
@@ -10,17 +10,17 @@ struct SpotLight{S <: Spectrum} <: Light
     function SpotLight(
         light_to_world::Transformation, i::S,
         total_width::Float32, falloff_start::Float32,
-    ) where S <: Spectrum
+    ) where S<:Spectrum
         new{S}(
-            LightδPosition, light_to_world, light_to_world |> inv,
-            Point3f(0f0) |> light_to_world, i,
-            total_width |> deg2rad |> cos, falloff_start |> deg2rad |> cos,
+            LightδPosition, light_to_world, inv(light_to_world),
+            light_to_world(Point3f(0f0)), i,
+            cos(deg2rad(total_width)), cos(deg2rad(falloff_start)),
         )
     end
 end
 
 function sample_li(s::SpotLight, ref::Interaction, ::Point2f)
-    wi = Vec3f(s.position - ref.p) |> normalize
+    wi = normalize(Vec3f(s.position - ref.p))
     pdf = 1f0
     visibility = VisibilityTester(
         ref, Interaction(s.position, ref.time, Vec3f(0f0), Normal3f(0f0)),
@@ -30,13 +30,13 @@ function sample_li(s::SpotLight, ref::Interaction, ::Point2f)
 end
 
 function falloff(s::SpotLight, w::Vec3f)::Float32
-    wl = w |> s.world_to_light |> normalize
+    wl = normalize(s.world_to_light(w))
     cosθ = wl[3]
     cosθ < s.cos_total_width && return 0f0
     cosθ ≥ s.cos_falloff_start && return 1f0
     # Compute falloff inside spotlight cone.
     δ = (cosθ - s.cos_total_width) / (s.cos_falloff_start - s.cos_total_width)
-    δ ^ 4
+    δ^4
 end
 
 @inline function power(s::SpotLight)
@@ -45,11 +45,11 @@ end
 
 function sample_le(
     s::SpotLight, u1::Point2f, ::Point2f, ::Float32,
-)::Tuple{RGBSpectrum, Ray, Normal3f, Float32, Float32}
-    w = uniform_sample_cone(u1, s.cos_total_width) |> s.light_to_world
-    ray = Ray(o=s.position, d=w)
-    light_normal = ray.d |> Normal3f
+)::Tuple{RGBSpectrum,Ray,Normal3f,Float32,Float32}
+    w = s.light_to_world(uniform_sample_cone(u1, s.cos_total_width))
+    ray = Ray(o = s.position, d = w)
+    light_normal = Normal3f(ray.d)
     pdf_pos = 1f0
-    pdf_dir = s.cos_total_width |> uniform_cone_pdf
+    pdf_dir = uniform_cone_pdf(s.cos_total_width)
     s.i * falloff(s, ray.d), ray, light_normal, pdf_pos, pdf_dir
 end

--- a/src/materials/bsdf.jl
+++ b/src/materials/bsdf.jl
@@ -36,7 +36,7 @@ mutable struct BSDF
     """
     Individual BxDF components. Maximum allowed number of components is 8.
     """
-    bxdfs::Vector{B} where B <: BxDF
+    bxdfs::Vector{B} where B<:BxDF
 
     function BSDF(si::SurfaceInteraction, η::Float32 = 1f0)
         ng = si.core.n
@@ -45,12 +45,12 @@ mutable struct BSDF
         ts = ns × ss
         new(
             η, ng, ns, ss, ts, UInt8(0),
-            Vector{B where B <: BxDF}(undef, MAX_BxDF),
+            Vector{B where B<:BxDF}(undef, MAX_BxDF),
         )
     end
 end
 
-function add!(b::BSDF, x::B) where B <: BxDF
+function add!(b::BSDF, x::B) where B<:BxDF
     @assert b.n_bxdfs < MAX_BxDF
     b.n_bxdfs += 1
     b.bxdfs[b.n_bxdfs] = x
@@ -106,7 +106,7 @@ to perfect specular reflection or refraction.
 """
 function sample_f(
     b::BSDF, wo_world::Vec3f, u::Point2f, type::UInt8,
-)::Tuple{Vec3f, RGBSpectrum, Float32, UInt8}
+)::Tuple{Vec3f,RGBSpectrum,Float32,UInt8}
     # Choose which BxDF to sample.
     matching_components = num_components(b, type)
     matching_components == 0 && return (
@@ -140,7 +140,7 @@ function sample_f(
     # TODO when to update sampled type
     sampled_type = bxdf.type
     wi, pdf, f, sampled_type_tmp = sample_f(bxdf, wo, u_remapped)
-    sampled_type_tmp ≢ nothing && (sampled_type = sampled_type_tmp;)
+    sampled_type_tmp ≢ nothing && (sampled_type = sampled_type_tmp)
 
     pdf ≈ 0f0 && return (
         Vec3f(0f0), RGBSpectrum(0f0), 0f0, BSDF_NONE,

--- a/src/model_loader.jl
+++ b/src/model_loader.jl
@@ -24,7 +24,7 @@ function _node_to_triangle_mesh!(
         mesh = mmesh.mesh
         m_vertices = mesh.position
         m_normals = convert(Vector{Trace.Normal3f}, mesh.normals)
-        m_faces = mesh |> faces
+        m_faces = faces(mesh)
         @assert length(eltype(m_faces)) == 3 "Only triangles supported."
         @assert length(m_vertices) == length(m_normals) "Number of normals is different from the number of vertices"
 
@@ -42,7 +42,7 @@ function _node_to_triangle_mesh!(
         )
         append!(triangles, [
             Trace.Triangle(core, triangle_mesh, i)
-            for i in UnitRange{UInt32}(0:length(m_faces) - 1)
+            for i in UnitRange{UInt32}(0:length(m_faces)-1)
         ])
         push!(triangle_meshes, triangle_mesh)
     end

--- a/src/primitive.jl
+++ b/src/primitive.jl
@@ -1,17 +1,17 @@
-struct GeometricPrimitive{T <: AbstractShape} <: Primitive
+struct GeometricPrimitive{T<:AbstractShape} <: Primitive
     shape::T
-    material::Maybe{M} where M <: Material
+    material::Maybe{M} where M<:Material
 
     function GeometricPrimitive(
         shape::T, material::Maybe{M} = nothing,
-    ) where {T <: AbstractShape, M <: Material}
+    ) where {T<:AbstractShape,M<:Material}
         new{T}(shape, material)
     end
 end
 
 function intersect!(
-    p::GeometricPrimitive{T}, ray::Union{Ray, RayDifferentials},
-) where T <: AbstractShape
+    p::GeometricPrimitive{T}, ray::Union{Ray,RayDifferentials},
+) where T<:AbstractShape
     intersects, t_hit, interaction = intersect(p.shape, ray)
     !intersects && return false, nothing
     ray.t_max = t_hit
@@ -20,16 +20,16 @@ function intersect!(
 end
 
 @inline function intersect_p(
-    p::GeometricPrimitive, ray::Union{Ray, RayDifferentials},
+    p::GeometricPrimitive, ray::Union{Ray,RayDifferentials},
 )
     intersect_p(p.shape, ray)
 end
-@inline world_bound(p::GeometricPrimitive) = p.shape |> world_bound
+@inline world_bound(p::GeometricPrimitive) = world_bound(p.shape)
 
 function compute_scattering!(
     p::GeometricPrimitive, si::SurfaceInteraction,
     allow_multiple_lobes::Bool, ::Type{T},
-) where T <: TransportMode
+) where T<:TransportMode
     !(p.material isa Nothing) && p.material(si, allow_multiple_lobes, T)
     @assert (si.core.n ⋅ si.shading.n) ≥ 0f0
 end

--- a/src/ray.jl
+++ b/src/ray.jl
@@ -19,7 +19,7 @@ Base.@kwdef mutable struct RayDifferentials <: AbstractRay
 end
 
 @inline function RayDifferentials(r::Ray)::RayDifferentials
-    RayDifferentials(o=r.o, d=r.d, t_max=r.t_max, time=r.time)
+    RayDifferentials(o = r.o, d = r.d, t_max = r.t_max, time = r.time)
 end
 
 @inline function set_direction!(r::AbstractRay, d::Vec3f)
@@ -28,7 +28,7 @@ end
 
 @inline check_direction!(r::AbstractRay) = set_direction!(r, r.d)
 
-function (r::Union{Ray, RayDifferentials})(t::Number)
+function (r::Union{Ray,RayDifferentials})(t::Number)
     r.o + r.d * t
 end
 

--- a/src/reflection/bxdf.jl
+++ b/src/reflection/bxdf.jl
@@ -1,16 +1,16 @@
-const BSDF_NONE         = 0b00000 |> UInt8
-const BSDF_REFLECTION   = 0b00001 |> UInt8
-const BSDF_TRANSMISSION = 0b00010 |> UInt8
-const BSDF_DIFFUSE      = 0b00100 |> UInt8
-const BSDF_GLOSSY       = 0b01000 |> UInt8
-const BSDF_SPECULAR     = 0b10000 |> UInt8
-const BSDF_ALL          = 0b11111 |> UInt8
+const BSDF_NONE = UInt8(0b00000)
+const BSDF_REFLECTION = UInt8(0b00001)
+const BSDF_TRANSMISSION = UInt8(0b00010)
+const BSDF_DIFFUSE = UInt8(0b00100)
+const BSDF_GLOSSY = UInt8(0b01000)
+const BSDF_SPECULAR = UInt8(0b10000)
+const BSDF_ALL = UInt8(0b11111)
 
-function Base.:&(b::B, type::UInt8)::Bool where B <: BxDF
+function Base.:&(b::B, type::UInt8)::Bool where B<:BxDF
     (b.type & type) == b.type
 end
 
-@inline function same_hemisphere(w::Vec3f, wp::Union{Vec3f, Normal3f})::Bool
+@inline function same_hemisphere(w::Vec3f, wp::Union{Vec3f,Normal3f})::Bool
     w[3] * wp[3] > 0
 end
 
@@ -20,7 +20,7 @@ In comparison, `sample_f` computes PDF value for the incident directions *it*
 chooses given the outgoing direction, while this returns a value of PDF
 for the given pair of directions.
 """
-@inline function compute_pdf(::B, wo::Vec3f, wi::Vec3f)::Float32 where B <: BxDF
+@inline function compute_pdf(::B, wo::Vec3f, wi::Vec3f)::Float32 where B<:BxDF
     same_hemisphere(wo, wi) ? abs(cos_θ(wi)) * (1f0 / π) : 0f0
 end
 
@@ -33,10 +33,10 @@ have to implement `compute_pdf` as well.
 """
 function sample_f(
     b::B, wo::Vec3f, sample::Point2f,
-)::Tuple{Vec3f, Float32, RGBSpectrum, Maybe{UInt8}} where B <: BxDF
-    wi::Vec3f = sample |> cosine_sample_hemisphere
+)::Tuple{Vec3f,Float32,RGBSpectrum,Maybe{UInt8}} where B<:BxDF
+    wi::Vec3f = cosine_sample_hemisphere(sample)
     # Flipping the direction if necessary.
-    wo[3] < 0 && (wi = Vec3f(wi[1], wi[2], -wi[3]);)
+    wo[3] < 0 && (wi = Vec3f(wi[1], wi[2], -wi[3]))
     pdf::Float32 = compute_pdf(b, wo, wi)
     wi, pdf, b(wo, wi), nothing
 end
@@ -49,11 +49,11 @@ of indices of refraction in the incident transmitted media respectively.
 Returned boolean indicates whether a valid refracted ray was returned
 or is it the case of total internal reflection.
 """
-function refract(wi::Vec3f, n::Normal3f, η::Float32)::Tuple{Bool, Vec3f}
+function refract(wi::Vec3f, n::Normal3f, η::Float32)::Tuple{Bool,Vec3f}
     # Compute cosθt using Snell's law.
     cos_θi = n ⋅ wi
-    sin2_θi = max(0f0, 1f0 - cos_θi ^ 2)
-    sin2_θt = (η ^ 2) * sin2_θi
+    sin2_θi = max(0f0, 1f0 - cos_θi^2)
+    sin2_θt = (η^2) * sin2_θi
     # Handle total internal reflection for transmission.
     sin2_θt >= 1 && return false, Vec3f(0f0)
     cos_θt = √(1f0 - sin2_θt)
@@ -75,13 +75,13 @@ function fresnel_dielectric(cos_θi::Float32, ηi::Float32, ηt::Float32)
     cos_θi = clamp(cos_θi, -1f0, 1f0)
     if cos_θi ≤ 0f0 # if not entering
         ηi, ηt = ηt, ηi
-        cos_θi = cos_θi |> abs
+        cos_θi = abs(cos_θi)
     end
     # Compute cos_θt using Snell's law.
-    sin_θi = √max(0f0, 1f0 - cos_θi ^ 2)
+    sin_θi = √max(0f0, 1f0 - cos_θi^2)
     sin_θt = sin_θi * ηi / ηt
     sin_θt ≥ 1f0 && return 1f0 # Handle total internal reflection.
-    cos_θt = √max(0f0, 1f0 - sin_θt ^ 2)
+    cos_θt = √max(0f0, 1f0 - sin_θt^2)
 
     r_parallel = (
         (ηt * cos_θi - ηi * cos_θt) /
@@ -91,7 +91,7 @@ function fresnel_dielectric(cos_θi::Float32, ηi::Float32, ηt::Float32)
         (ηi * cos_θi - ηt * cos_θt) /
         (ηi * cos_θi + ηt * cos_θt)
     )
-    0.5f0 * (r_parallel ^ 2 + r_perp ^ 2)
+    0.5f0 * (r_parallel^2 + r_perp^2)
 end
 
 """
@@ -101,7 +101,7 @@ k - is referred to as the absorption coefficient.
 """
 function fresnel_conductor(
     cos_θi::Float32, ηi::S, ηt::S, k::S,
-) where S <: Spectrum
+) where S<:Spectrum
     cos_θi = clamp(cos_θi, -1f0, 1f0)
     η = ηt / ηi
     ηk = k / ηi
@@ -125,7 +125,7 @@ function fresnel_conductor(
 end
 
 abstract type Fresnel end
-struct FresnelConductor{S <: Spectrum} <: Fresnel
+struct FresnelConductor{S<:Spectrum} <: Fresnel
     ηi::S
     ηt::S
     k::S

--- a/src/reflection/lambertian.jl
+++ b/src/reflection/lambertian.jl
@@ -2,7 +2,7 @@
 Lambertian Reflection models a perfect diffuse surface
 that scatters incident illumination equally in all directions.
 """
-struct LambertianReflection{S <: Spectrum} <: BxDF
+struct LambertianReflection{S<:Spectrum} <: BxDF
     """
     Reflectance spectrum, which is the fraction
     of incident light that is scattered.
@@ -10,7 +10,7 @@ struct LambertianReflection{S <: Spectrum} <: BxDF
     r::S
     type::UInt8
 
-    function LambertianReflection(r::S) where S <: Spectrum
+    function LambertianReflection(r::S) where S<:Spectrum
         new{S}(r, BSDF_DIFFUSE | BSDF_REFLECTION)
     end
 end
@@ -19,7 +19,7 @@ end
 Reflection distribution is constant and divides reflectance spectrum
 equally over the hemisphere.
 """
-function (l::LambertianReflection{S})(::Vec3f, ::Vec3f)::RGBSpectrum where S <: Spectrum
+function (l::LambertianReflection{S})(::Vec3f, ::Vec3f)::RGBSpectrum where S<:Spectrum
     l.r * (1f0 / π)
 end
 
@@ -28,7 +28,7 @@ Directional-hemisphirical reflectance value is constant.
 """
 function ρ(
     l::LambertianReflection{S}, ::Vec3f, ::Int32, ::Vector{Point2f},
-) where S <: Spectrum
+) where S<:Spectrum
     l.r
 end
 
@@ -37,7 +37,7 @@ Hemispherical-hemisphirical reflectance value is constant.
 """
 function ρ(
     l::LambertianReflection{S}, ::Vector{Point2f}, ::Vector{Point2f},
-) where S <: Spectrum
+) where S<:Spectrum
     l.r
 end
 
@@ -45,37 +45,37 @@ end
 """
 Lambertian Transmission models perfect transmission.
 """
-struct LambertianTransmission{S <: Spectrum} <: BxDF
+struct LambertianTransmission{S<:Spectrum} <: BxDF
     t::S
     type::UInt8
 
-    function LambertianTransmission(t::S) where S <: Spectrum
+    function LambertianTransmission(t::S) where S<:Spectrum
         new{S}(t, BSDF_DIFFUSE | BSDF_TRANSMISSION)
     end
 end
 
-function (t::LambertianTransmission{S})(::Vec3f, ::Vec3f)::RGBSpectrum where S <: Spectrum
+function (t::LambertianTransmission{S})(::Vec3f, ::Vec3f)::RGBSpectrum where S<:Spectrum
     t.t * (1f0 / π)
 end
 
 function ρ(
     t::LambertianTransmission{S}, ::Vec3f, ::Int32, ::Vector{Point2f},
-) where S <: Spectrum
+) where S<:Spectrum
     t.t
 end
 
 function ρ(
     t::LambertianTransmission{S}, ::Vector{Point2f}, ::Vector{Point2f},
-) where S <: Spectrum
+) where S<:Spectrum
     t.t
 end
 
 function sample_f(
     b::LambertianTransmission{S}, wo::Vec3f, sample::Point2f,
-)::Tuple{Vec3f, Float32, RGBSpectrum, Maybe{UInt8}} where S <: Spectrum
-    wi = sample |> cosine_sample_hemisphere
+)::Tuple{Vec3f,Float32,RGBSpectrum,Maybe{UInt8}} where S<:Spectrum
+    wi = cosine_sample_hemisphere(sample)
     # Flipping the direction if necessary.
-    wo[3] > 0 && (wi = Vec3f(wi[1], wi[2], -wi[3]);)
+    wo[3] > 0 && (wi = Vec3f(wi[1], wi[2], -wi[3]))
     pdf = compute_pdf(b, wo, wi)
     wi, pdf, b(wo, wi), nothing
 end

--- a/src/reflection/microfacet.jl
+++ b/src/reflection/microfacet.jl
@@ -3,14 +3,14 @@ Describes rough surfaces by V-shaped microfacets described by a spherical
 Gaussian distribution with parameter `σ` --- the standard deviation
 of the microfacet angle.
 """
-struct OrenNayar{S <: Spectrum} <: BxDF
+struct OrenNayar{S<:Spectrum} <: BxDF
     r::S
     a::Float32
     b::Float32
     type::UInt8
 
-    function OrenNayar(r::S, σ::Float32) where S <: Spectrum
-        σ = σ |> deg2rad
+    function OrenNayar(r::S, σ::Float32) where S<:Spectrum
+        σ = deg2rad(σ)
         σ2 = σ * σ
         a = 1f0 - (σ2 / (2f0 * (σ2 + 0.33f0)))
         b = 0.45f0 * σ2 / (σ2 + 0.09f0)
@@ -19,15 +19,15 @@ struct OrenNayar{S <: Spectrum} <: BxDF
 end
 
 function (o::OrenNayar)(wo::Vec3f, wi::Vec3f)::RGBSpectrum
-    sin_θi = wi |> sin_θ
-    sin_θo = wo |> sin_θ
+    sin_θi = sin_θ(wi)
+    sin_θo = sin_θ(wo)
     # Compute cosine term of Oren-Nayar model.
     max_cos = 0f0
     if sin_θi > 1f-4 && sin_θo > 1f-4
-        sin_ϕi = wi |> sin_ϕ
-        cos_ϕi = wi |> cos_ϕ
-        sin_ϕo = wo |> sin_ϕ
-        cos_ϕo = wo |> cos_ϕ
+        sin_ϕi = sin_ϕ(wi)
+        cos_ϕi = cos_ϕ(wi)
+        sin_ϕo = sin_ϕ(wo)
+        cos_ϕo = cos_ϕ(wo)
         max_cos = max(0f0, cos_ϕi * cos_ϕo + sin_ϕi * sin_ϕo)
     end
     # Compute sine & tangent terms of Oren-Nayar model.
@@ -63,11 +63,11 @@ struct TrowbridgeReitzDistribution <: MicrofacetDistribution
 end
 
 function λ(trd::TrowbridgeReitzDistribution, w::Vec3f)::Float32
-    θ = w |> tan_θ |> abs
+    θ = abs(tan_θ(w))
     isinf(θ) && return 0f0
 
-    α = √(cos_ϕ(w) ^ 2 * trd.α_x ^ 2 + sin_ϕ(w) ^ 2 * trd.α_y ^ 2)
-    α²tanθ² = (α * θ) ^ 2
+    α = √(cos_ϕ(w)^2 * trd.α_x^2 + sin_ϕ(w)^2 * trd.α_y^2)
+    α²tanθ² = (α * θ)^2
     (-1f0 + √(1f0 + α²tanθ²)) / 2f0
 end
 
@@ -79,8 +79,8 @@ correspond to near-perfect specular reflection, rather than by specifying
 @inline function roughness_to_α(roughness::Float32)::Float32
     roughness = max(1f-3, roughness)
     x = log(roughness)
-    1.62142f0 + 0.819955f0 * x + 0.1734f0 * x ^ 2 +
-        0.0171201f0 * x ^ 3 + 0.000640711f0 * x ^ 4
+    1.62142f0 + 0.819955f0 * x + 0.1734f0 * x^2 +
+    0.0171201f0 * x^3 + 0.000640711f0 * x^4
 end
 
 @inline function G1(m::MicrofacetDistribution, w::Vec3f)::Float32
@@ -96,12 +96,12 @@ Distribution function, which gives the differential area of microfacets
 with the surface normal `w`.
 """
 function D(trd::TrowbridgeReitzDistribution, w::Vec3f)::Float32
-    tan_θ² = tan_θ(w) ^ 2
+    tan_θ² = tan_θ(w)^2
     isinf(tan_θ²) && return 0f0
 
-    cos_θ⁴ = cos_θ(w) ^ 4
-    e = (cos_ϕ(w) ^ 2 / (trd.α_x ^ 2) + sin_ϕ(w) ^ 2 / (trd.α_y ^ 2)) * tan_θ²
-    1f0 / (π * trd.α_x * trd.α_y * cos_θ⁴ * (1f0 + e) ^ 2)
+    cos_θ⁴ = cos_θ(w)^4
+    e = (cos_ϕ(w)^2 / (trd.α_x^2) + sin_ϕ(w)^2 / (trd.α_y^2)) * tan_θ²
+    1f0 / (π * trd.α_x * trd.α_y * cos_θ⁴ * (1f0 + e)^2)
 end
 
 function compute_pdf(m::MicrofacetDistribution, wo::Vec3f, wh::Vec3f)::Float32
@@ -111,25 +111,25 @@ end
 
 function _trowbridge_reitz_sample(
     cosθ::Float32, u1::Float32, u2::Float32,
-)::Tuple{Float32, Float32}
+)::Tuple{Float32,Float32}
     if cosθ > 0.9999f0 # Special case -- normal incidence.
         r = √(u1 / (1f0 - u1))
         ϕ = 6.28318530718 * u2
         return r * cos(ϕ), r * sin(ϕ)
     end
 
-    sinθ = √(max(0f0, 1f0 - cosθ ^ 2))
+    sinθ = √(max(0f0, 1f0 - cosθ^2))
     tanθ = sinθ / cosθ
     a = 1f0 / tanθ
-    g1 = 2f0 / (1f0 + √(1f0 + 1f0 / (a ^ 2)))
+    g1 = 2f0 / (1f0 + √(1f0 + 1f0 / (a^2)))
 
     # Sample slope x.
     a = 2f0 * u1 / g1 - 1f0
-    tmp = 1f0 / (a ^ 2 - 1f0)
-    tmp > 1f10 && (tmp = 1f10;)
+    tmp = 1f0 / (a^2 - 1f0)
+    tmp > 1f10 && (tmp = 1f10)
     b = tanθ
-    b² = b ^ 2
-    d = √(max(0f0, b² * tmp ^ 2 - (a ^ 2 - b²) * tmp))
+    b² = b^2
+    d = √(max(0f0, b² * tmp^2 - (a^2 - b²) * tmp))
     slope_x1, slope_x2 = b * tmp - d, b * tmp + d
     slope_x = (a < 0 || slope_x2 > 1f0 / tanθ) ? slope_x1 : slope_x2
 
@@ -143,9 +143,10 @@ function _trowbridge_reitz_sample(
     end
     z = (
         (u2 * (u2 * (u2 * 0.27385f0 - 0.73369f0) + 0.46341f0))
-        / (u2 * (u2 * (u2 * 0.093073f0 + 0.309420f0) - 1f0) + 0.597999f0)
+        /
+        (u2 * (u2 * (u2 * 0.093073f0 + 0.309420f0) - 1f0) + 0.597999f0)
     )
-    slope_y = s * z * √(1f0 + slope_x ^ 2)
+    slope_y = s * z * √(1f0 + slope_x^2)
 
     @assert !isinf(slope_y) && !isnan(slope_y)
     slope_x, slope_y
@@ -155,7 +156,7 @@ function trowbridge_reitz_sample(
     wi::Vec3f, α_x::Float32, α_y::Float32, u1::Float32, u2::Float32,
 )::Vec3f
     # Stretch wi.
-    wi_stretch = Vec3f(wi[1] * α_x, wi[2] * α_y, wi[3]) |> normalize
+    wi_stretch = normalize(Vec3f(wi[1] * α_x, wi[2] * α_y, wi[3]))
     slope_x, slope_y = _trowbridge_reitz_sample(cos_θ(wi_stretch), u1, u2)
     # Rotate.
     c, s = cos_ϕ(wi_stretch), sin_ϕ(wi_stretch)
@@ -166,7 +167,7 @@ function trowbridge_reitz_sample(
     slope_x *= α_x
     slope_y *= α_y
     # Compute normal.
-    Vec3f(-slope_x, -slope_y, 1f0) |> normalize
+    normalize(Vec3f(-slope_x, -slope_y, 1f0))
 end
 
 function sample_wh(
@@ -182,59 +183,59 @@ function sample_wh(
     cosθ = 0f0
     ϕ = 2f0 * π * u[2]
     if trd.α_x ≈ trd.α_y
-        tanθ² = trd.α_x ^ 2 * u[1] / (1f0 - u[1])
+        tanθ² = trd.α_x^2 * u[1] / (1f0 - u[1])
         cosθ = 1f0 / √(1f0 + tanθ²)
     else
         ϕ = atan(trd.α_y / trd.α_x * tan(2f0 * π * u[2] + 0.5f0 * π))
         u[2] > 0.5f0 && (ϕ += π)
         sinϕ, cosϕ = sin(ϕ), cos(ϕ)
-        α_x², α_y² = trd.α_x ^ 2, trd.α_y ^ 2
-        α² = 1f0 / (cosϕ ^ 2 / α_x² + sinϕ ^ 2 / α_y²)
+        α_x², α_y² = trd.α_x^2, trd.α_y^2
+        α² = 1f0 / (cosϕ^2 / α_x² + sinϕ^2 / α_y²)
         tanθ² = α² * u[1] / (1f0 - u[1])
         cosθ = 1f0 / √(1f0 + tanθ²)
     end
 
-    sinθ = √(max(0f0, 1f0 - cosθ ^ 2))
+    sinθ = √(max(0f0, 1f0 - cosθ^2))
     wh = spherical_direction(sinθ, cosθ, ϕ)
     same_hemisphere(wo, wh) ? wh : -wh
 end
 
 
-struct MicrofacetReflection{S <: Spectrum, T <: TransportMode} <: BxDF
+struct MicrofacetReflection{S<:Spectrum,T<:TransportMode} <: BxDF
     r::S
-    distribution::D where D <: MicrofacetDistribution
-    fresnel::F where F <: Fresnel
+    distribution::D where D<:MicrofacetDistribution
+    fresnel::F where F<:Fresnel
 
     type::UInt8
 
     function MicrofacetReflection(
-        r::S, distribution::D, fresnel::F, ::Type{T}
+        r::S, distribution::D, fresnel::F, ::Type{T},
     ) where {
-        S <: Spectrum, D <: MicrofacetDistribution,
-        F <: Fresnel, T <: TransportMode,
+        S<:Spectrum,D<:MicrofacetDistribution,
+        F<:Fresnel,T<:TransportMode,
     }
-        new{S, T}(r, distribution, fresnel, BSDF_REFLECTION | BSDF_GLOSSY)
+        new{S,T}(r, distribution, fresnel, BSDF_REFLECTION | BSDF_GLOSSY)
     end
 end
 
-function (m::MicrofacetReflection{S, T})(
+function (m::MicrofacetReflection{S,T})(
     wo::Vec3f, wi::Vec3f,
-)::RGBSpectrum where {S <: Spectrum, T <: TransportMode}
-    cosθo = wo |> cos_θ |> abs
-    cosθi = wi |> cos_θ |> abs
+)::RGBSpectrum where {S<:Spectrum,T<:TransportMode}
+    cosθo = abs(cos_θ(wo))
+    cosθi = abs(cos_θ(wi))
     wh = wi + wo
     # Degenerate cases for microfacet reflection.
     (cosθi ≈ 0 || cosθo ≈ 0) && return S(0f0)
     wh ≈ Vec3f(0) && return S(0f0)
-    wh = wh |> normalize
+    wh = normalize(wh)
     f = m.fresnel(wi ⋅ face_forward(wh, Vec3f(0, 0, 1)))
     m.r * D(m.distribution, wh) * G(m.distribution, wo, wi) *
-        f / (4f0 * cosθi * cosθo)
+    f / (4f0 * cosθi * cosθo)
 end
 
 function sample_f(
-    m::MicrofacetReflection{S, T}, wo::Vec3f, u::Point2f,
-)::Tuple{Vec3f, Float32, RGBSpectrum, Maybe{UInt8}} where {S <: Spectrum, T <: TransportMode}
+    m::MicrofacetReflection{S,T}, wo::Vec3f, u::Point2f,
+)::Tuple{Vec3f,Float32,RGBSpectrum,Maybe{UInt8}} where {S<:Spectrum,T<:TransportMode}
     wo[3] ≈ 0 && return Vec3f(0f0), 0f0, S(0f0), nothing
 
     # Sample microfacet orientation `wh` and reflected direction `wi`.
@@ -252,14 +253,14 @@ end
     m::MicrofacetReflection, wo::Vec3f, wi::Vec3f,
 )::Float32
     !same_hemisphere(wo, wi) && return 0f0
-    wh = (wo + wi) |> normalize
+    wh = normalize((wo + wi))
     compute_pdf(m.distribution, wo, wh) / (4f0 * wo ⋅ wh)
 end
 
 
-struct MicrofacetTransmission{S <: Spectrum, T <: TransportMode} <: BxDF
+struct MicrofacetTransmission{S<:Spectrum,T<:TransportMode} <: BxDF
     t::S
-    distribution::D where D <: MicrofacetDistribution
+    distribution::D where D<:MicrofacetDistribution
     η_a::Float32
     η_b::Float32
     fresnel::FresnelDielectric
@@ -268,43 +269,44 @@ struct MicrofacetTransmission{S <: Spectrum, T <: TransportMode} <: BxDF
 
     function MicrofacetTransmission(
         t::S, distribution::D, η_a::Float32, η_b::Float32, ::Type{T},
-    ) where {S <: Spectrum, D <: MicrofacetDistribution, T <: TransportMode}
-        new{S, T}(
+    ) where {S<:Spectrum,D<:MicrofacetDistribution,T<:TransportMode}
+        new{S,T}(
             t, distribution, η_a, η_b, FresnelDielectric(η_a, η_b),
             BSDF_TRANSMISSION | BSDF_GLOSSY,
         )
     end
 end
 
-function (m::MicrofacetTransmission{S, T})(
+function (m::MicrofacetTransmission{S,T})(
     wo::Vec3f, wi::Vec3f,
-)::RGBSpectrum where {S <: Spectrum, T <: TransportMode}
+)::RGBSpectrum where {S<:Spectrum,T<:TransportMode}
     same_hemisphere(wo, wi) && return S(0f0) # Only transmission.
 
-    cosθo, cosθi = wo |> cos_θ, wi |> cos_θ
+    cosθo, cosθi = cos_θ(wo), cos_θ(wi)
     (cosθo ≈ 0 || cosθi ≈ 0) && return S(0f0)
     # Compute `wh` from `wo` & `wi` for microfacet transmission.
     η = cos_θ(wo) > 0f0 ? (m.η_b / m.η_a) : (m.η_a / m.η_b)
-    wh = (wo + wi * η) |> normalize
-    wh[3] < 0 && (wh = -wh;)
+    wh = normalize((wo + wi * η))
+    wh[3] < 0 && (wh = -wh)
     # Only transmission if `wh` is on the same side.
     d_o, d_i = wo ⋅ wh, wi ⋅ wh
     (d_o * d_i) > 0 && return S(0f0)
 
-    f = d_o |> m.fresnel
+    f = m.fresnel(d_o)
     denom = d_o + η * d_i
     factor = T isa Radiance ? (1f0 / η) : 1f0
 
     dd, dg = D(m.distribution, wh), G(m.distribution, wo, wi)
     (S(1f0) - f) * m.t * abs(
-        dd * dg * d_o * d_i * η ^ 2 * factor ^ 2
-        / (cosθi * cosθo * denom ^ 2)
+        dd * dg * d_o * d_i * η^2 * factor^2
+        /
+        (cosθi * cosθo * denom^2),
     )
 end
 
 function sample_f(
-    m::MicrofacetTransmission{S, T}, wo::Vec3f, u::Point2f,
-)::Tuple{Vec3f, Float32, RGBSpectrum, Maybe{UInt8}} where {S <: Spectrum, T <: TransportMode}
+    m::MicrofacetTransmission{S,T}, wo::Vec3f, u::Point2f,
+)::Tuple{Vec3f,Float32,RGBSpectrum,Maybe{UInt8}} where {S<:Spectrum,T<:TransportMode}
     wo[3] ≈ 0 && return Vec3f(0f0), 0f0, S(0f0), nothing
     wh = sample_wh(m.distribution, wo, u)
     (wo ⋅ wh) < 0 && return Vec3f(0f0), 0f0, S(0f0), nothing
@@ -323,13 +325,13 @@ function compute_pdf(
     same_hemisphere(wo, wi) && return 0f0
 
     η = cos_θ(wo) > 0f0 ? (m.η_b / m.η_a) : (m.η_a / m.η_b)
-    wh = (wo + wi * η) |> normalize
+    wh = normalize((wo + wi * η))
     @assert !isnan(wh)
     d_o, d_i = wo ⋅ wh, wi ⋅ wh
     (d_o * d_i) > 0 && return 0f0
 
     # Compute change of variables `∂wh∂wi` for microfacet transmission.
     denom = d_o + η * d_i
-    ∂wh∂wi = abs(d_i * η ^ 2 / (denom ^ 2))
+    ∂wh∂wi = abs(d_i * η^2 / (denom^2))
     compute_pdf(m.distribution, wo, wh) * ∂wh∂wi
 end

--- a/src/sampler/sampler.jl
+++ b/src/sampler/sampler.jl
@@ -27,8 +27,8 @@ end
 
 function get_camera_sample(sampler::AbstractSampler, p_raster::Point2f)
     p_film = p_raster .+ get_2d(sampler)
-    time = sampler |> get_1d
-    p_lens = sampler |> get_2d
+    time = get_1d(sampler)
+    p_lens = get_2d(sampler)
     CameraSample(p_film, p_lens, time)
 end
 
@@ -68,14 +68,14 @@ end
 
 function get_1d_array(sampler::Sampler, n::Integer)
     sampler.array_1d_offset == length(sampler.sample_array_1d) + 1 && return nothing
-    arr = @view sampler.sample_array_1d[sampler.array_1d_offset][sampler.current_pixel_sample_id * n:end]
+    arr = @view sampler.sample_array_1d[sampler.array_1d_offset][sampler.current_pixel_sample_id*n:end]
     sampler.array_1d_offset += 1
     arr
 end
 
 function get_2d_array(sampler::Sampler, n::Integer)
     sampler.array_2d_offset == length(sampler.sample_array_2d) + 1 && return nothing
-    arr = @view sampler.sample_array_2d[sampler.array_2d_offset][sampler.current_pixel_sample_id * n:end]
+    arr = @view sampler.sample_array_2d[sampler.array_2d_offset][sampler.current_pixel_sample_id*n:end]
     sampler.array_2d_offset += 1
     arr
 end
@@ -103,7 +103,7 @@ start_pixel(p::PixelSampler, point::Point2f) = start_pixel(p.sampler, point)
 
 function start_next_sample(ps::PixelSampler)
     ps.current_1d_dimension = ps.current_2d_dimension = 1
-    ps.sampler |> start_next_sample
+    start_next_sample(ps.sampler)
 end
 
 function set_sample_number(ps::PixelSampler, sample_num::Integer)::Bool

--- a/src/sampler/sampling.jl
+++ b/src/sampler/sampling.jl
@@ -6,21 +6,21 @@ struct Distribution1D
     func_int::Float32
 
     function Distribution1D(func::Vector{Float32})
-        n = func |> length
+        n = length(func)
         cdf = Vector{Float32}(undef, n + 1)
         # Compute integral of step function at `xᵢ`.
         cdf[1] = 0f0
         @inbounds for i in 2:length(cdf)
-            cdf[i] = cdf[i - 1] + func[i - 1] / n
+            cdf[i] = cdf[i-1] + func[i-1] / n
         end
         # Transform step function integral into CDF.
-        func_int = cdf[n + 1]
+        func_int = cdf[n+1]
         if func_int ≈ 0f0
-            @inbounds for i in 2:n + 1
+            @inbounds for i in 2:n+1
                 cdf[i] = i / n
             end
         else
-            @inbounds for i in 2:n + 1
+            @inbounds for i in 2:n+1
                 cdf[i] /= func_int
             end
         end
@@ -36,7 +36,7 @@ function sample_discrete(d::Distribution1D, u::Float32)
     offset = clamp(offset, 1, length(d.cdf) - 1)
 
     pdf = d.func_int > 0 ? d.func[offset] / (d.func_int * length(d.func)) : 0f0
-    u_remapped = (u - d.cdf[offset]) / (d.cdf[offset + 1] - d.cdf[offset])
+    u_remapped = (u - d.cdf[offset]) / (d.cdf[offset+1] - d.cdf[offset])
     offset, pdf, u_remapped
 end
 
@@ -68,7 +68,7 @@ end
 end
 
 @inline function reverse_bits(n::UInt64)::UInt64
-    n0 = reverse_bits(UInt32((n << 32) >> 32)) |> UInt64
-    n1 = reverse_bits(UInt32(n >> 32)) |> UInt64
+    n0 = UInt64(reverse_bits(UInt32((n << 32) >> 32)))
+    n1 = UInt64(reverse_bits(UInt32(n >> 32)))
     return (n0 << 32) | n1
 end

--- a/src/sampler/stratified.jl
+++ b/src/sampler/stratified.jl
@@ -1,11 +1,11 @@
 struct StratifiedSampler <: AbstractSampler
     pixel_sampler::PixelSampler
-    pixel_samlpes::Tuple{UInt32, UInt32}
+    pixel_samlpes::Tuple{UInt32,UInt32}
     jitter_samples::Bool
 end
 
 function StratifiedSampler(
-    pixel_samples::Tuple{Integer, Integer}, jitter_samples::Bool,
+    pixel_samples::Tuple{Integer,Integer}, jitter_samples::Bool,
     n_sampled_dimensions::Int64,
 )
     StratifiedSampler(

--- a/src/shapes/Shape.jl
+++ b/src/shapes/Shape.jl
@@ -8,14 +8,14 @@ struct ShapeCore
         object_to_world::Transformation, reverse_orientation::Bool,
     )
         new(
-            object_to_world, object_to_world |> inv, reverse_orientation,
-            object_to_world |> swaps_handedness,
+            object_to_world, inv(object_to_world), reverse_orientation,
+            swaps_handedness(object_to_world),
         )
     end
 end
 
 function world_bound(s::AbstractShape)::Bounds3
-    s |> object_bound |> s.core.object_to_world
+    s.core.object_to_world(object_bound(s))
 end
 
 include("sphere.jl")

--- a/src/shapes/sphere.jl
+++ b/src/shapes/sphere.jl
@@ -38,11 +38,11 @@ end
 
 function solve_quadratic(a::Float32, b::Float32, c::Float32)
     # Find disriminant.
-    d = b ^ 2 - 4 * a * c
+    d = b^2 - 4 * a * c
     if d < 0
         return false, NaN32, NaN32
     end
-    d = d |> sqrt
+    d = sqrt(d)
     # Compute roots.
     q = -0.5f0 * (b + (b < 0 ? -d : d))
     t0 = q / a
@@ -64,8 +64,8 @@ Test if hit point exceeds clipping parameters of the sphere.
 """
 function test_clipping(s::Sphere, p::Point3f, ϕ::Float32)::Bool
     (s.z_min > -s.radius && p[3] < s.z_min) ||
-    (s.z_max < s.radius && p[3] > s.z_max) ||
-    ϕ > s.ϕ_max
+        (s.z_max < s.radius && p[3] > s.z_max) ||
+        ϕ > s.ϕ_max
 end
 
 function compute_ϕ(p::Point3f)::Float32
@@ -100,7 +100,7 @@ function ∂n(
 )
     ∂2p∂u2 = -s.ϕ_max * s.ϕ_max * Vec3f(p[1], p[2], 0f0)
     ∂2p∂u∂v = (s.θ_max - s.θ_min) * p[3] * s.ϕ_max * Vec3f(-sin_ϕ, cos_ϕ, 0f0)
-    ∂2p∂v2 = (s.θ_max - s.θ_min) ^ 2 * -p
+    ∂2p∂v2 = (s.θ_max - s.θ_min)^2 * -p
     # Compute coefficients for fundamental forms.
     E = ∂p∂u ⋅ ∂p∂u
     F = ∂p∂u ⋅ ∂p∂v
@@ -113,78 +113,78 @@ function ∂n(
     inv_egf = 1f0 / (E * G - F * F)
     ∂n∂u = Normal3f(
         (f * F - e * G) * inv_egf * ∂p∂u +
-        (e * F - f * E) * inv_egf * ∂p∂v
+        (e * F - f * E) * inv_egf * ∂p∂v,
     )
     ∂n∂v = Normal3f(
         (g * F - f * G) * inv_egf * ∂p∂u +
-        (f * F - g * E) * inv_egf * ∂p∂v
+        (f * F - g * E) * inv_egf * ∂p∂v,
     )
     ∂n∂u, ∂n∂v
 end
 
 function intersect(
-    s::Sphere, ray::Union{Ray, RayDifferentials}, ::Bool = false,
+    s::Sphere, ray::Union{Ray,RayDifferentials}, ::Bool = false,
 )
     # Transform ray to object space.
-    or = ray |> s.core.world_to_object
+    or = s.core.world_to_object(ray)
     # Substitute ray into sphere equation.
-    a = norm(or.d) ^ 2
+    a = norm(or.d)^2
     b = 2 * or.o ⋅ or.d
-    c = norm(or.o) ^ 2 - s.radius ^ 2
+    c = norm(or.o)^2 - s.radius^2
     # Solve quadratic equation for t.
     exists, t0, t1 = solve_quadratic(a, b, c)
     !exists && return false, nothing, nothing
     (t0 > or.t_max || t1 < 0f0) && return false, nothing, nothing
-    t0 < 0 && (t0 = t1;)
+    t0 < 0 && (t0 = t1)
 
     shape_hit = t0
-    hit_point = refine_intersection(t0 |> or, s)
-    ϕ = hit_point |> compute_ϕ
+    hit_point = refine_intersection(or(t0), s)
+    ϕ = compute_ϕ(hit_point)
     # Test sphere intersection against clipping parameters.
     if test_clipping(s, hit_point, ϕ)
         shape_hit = t1
-        hit_point = refine_intersection(t1 |> or, s)
-        ϕ = hit_point |> compute_ϕ
+        hit_point = refine_intersection(or(t1), s)
+        ϕ = compute_ϕ(hit_point)
         test_clipping(s, hit_point, ϕ) && return false, nothing, nothing
     end
     # Find parametric representation of hit point.
     u = ϕ / s.ϕ_max
-    θ = clamp(hit_point[3] / s.radius, -1f0, 1f0) |> acos
+    θ = acos(clamp(hit_point[3] / s.radius, -1f0, 1f0))
     v = (θ - s.θ_min) / (s.θ_max - s.θ_min)
 
-    sin_ϕ, cos_ϕ = hit_point |> precompute_ϕ
+    sin_ϕ, cos_ϕ = precompute_ϕ(hit_point)
     ∂p∂u, ∂p∂v = ∂p(s, hit_point, θ, sin_ϕ, cos_ϕ)
     ∂n∂u, ∂n∂v = ∂n(s, hit_point, sin_ϕ, cos_ϕ, ∂p∂u, ∂p∂v)
 
-    interaction = SurfaceInteraction(
+    interaction = s.core.object_to_world(SurfaceInteraction(
         hit_point, ray.time, -ray.d, Point2f(u, v),
         ∂p∂u, ∂p∂v, ∂n∂u, ∂n∂v, s,
-    ) |> s.core.object_to_world
+    ))
     true, shape_hit, interaction
 end
 
 function intersect_p(
-    s::Sphere, ray::Union{Ray, RayDifferentials}, ::Bool = false,
+    s::Sphere, ray::Union{Ray,RayDifferentials}, ::Bool = false,
 )::Bool
     # Transform ray to object space.
-    or = ray |> s.core.world_to_object
+    or = s.core.world_to_object(ray)
     # Substitute ray into sphere equation.
-    a = norm(or.d) ^ 2
+    a = norm(or.d)^2
     b = 2f0 * or.o ⋅ or.d
-    c = norm(or.o) ^ 2 - s.radius ^ 2
+    c = norm(or.o)^2 - s.radius^2
     # Solve quadratic equation for t.
     exists, t0, t1 = solve_quadratic(a, b, c)
     !exists && return false
     (t0 > or.t_max || t1 < 0f0) && return false
-    t0 < 0 && (t0 = t1;)
+    t0 < 0 && (t0 = t1)
 
-    hit_point = refine_intersection(t0 |> or, s)
-    ϕ = hit_point |> compute_ϕ
+    hit_point = refine_intersection(or(t0), s)
+    ϕ = compute_ϕ(hit_point)
     # Test sphere intersection against clipping parameters.
     if test_clipping(s, hit_point, ϕ)
         shape_hit = t1
-        hit_point = refine_intersection(t1 |> or, s)
-        ϕ = hit_point |> compute_ϕ
+        hit_point = refine_intersection(or(t1), s)
+        ϕ = compute_ϕ(hit_point)
         test_clipping(s, hit_point, ϕ) && return false
     end
     true

--- a/src/spectrum.jl
+++ b/src/spectrum.jl
@@ -1,8 +1,8 @@
 @inline function XYZ_to_RGB(xyz::Point3f)
     Point3f(
-         3.240479f0 * xyz[1] - 1.537150f0 * xyz[2] - 0.498535f0 * xyz[3],
+        3.240479f0 * xyz[1] - 1.537150f0 * xyz[2] - 0.498535f0 * xyz[3],
         -0.969256f0 * xyz[1] + 1.875991f0 * xyz[2] + 0.041556f0 * xyz[3],
-         0.055648f0 * xyz[1] - 0.204043f0 * xyz[2] + 1.057311f0 * xyz[3],
+        0.055648f0 * xyz[1] - 0.204043f0 * xyz[2] + 1.057311f0 * xyz[3],
     )
 end
 @inline function RGB_to_XYZ(rgb::Point3f)
@@ -13,46 +13,46 @@ end
     )
 end
 
-Base.:(==)(c::C, i) where C <: Spectrum = all(c.c .== i)
-Base.:(==)(c1::C, c2::C) where C <: Spectrum = all(c1.c .== c2.c)
-Base.:+(c1::C, c2::C) where C <: Spectrum = C(c1.c .+ c2.c)
-Base.:+(c1::C, c) where C <: Spectrum = C(c1.c .+ c)
-Base.:-(c::C) where C <: Spectrum = -c.c |> C(-c.c)
-Base.:-(c1::C, c::Number) where C <: Spectrum = C(c1.c .- c)
-Base.:-(c1::C, c2::C) where C <: Spectrum = C(c1.c .- c2.c)
-Base.:*(c1::C, c2::C) where C <: Spectrum = C(c1.c .* c2.c)
-Base.:*(c1::C, f::Number) where C <: Spectrum = C(c1.c .* f)
-Base.:*(f::Number, c1::C) where C <: Spectrum = C(c1.c .* f)
-Base.:/(c1::C, c2::C) where C <: Spectrum = C(c1.c ./ c2.c)
-Base.:/(c1::C, f::Number) where C <: Spectrum = C(c1.c ./ f)
-Base.sqrt(c::C) where C <: Spectrum = C(c.c .|> sqrt)
-Base.:^(c::C, e::Number) where C <: Spectrum = C(c.c .^ e)
-Base.exp(c::C) where C <: Spectrum = C(c.c .|> exp)
-lerp(c1::C, c2::C, t::Float32) where C <: Spectrum = (1f0 - t) * c1 + t * c2
+Base.:(==)(c::C, i) where C<:Spectrum = all(c.c .== i)
+Base.:(==)(c1::C, c2::C) where C<:Spectrum = all(c1.c .== c2.c)
+Base.:+(c1::C, c2::C) where C<:Spectrum = C(c1.c .+ c2.c)
+Base.:+(c1::C, c) where C<:Spectrum = C(c1.c .+ c)
+Base.:-(c::C) where C<:Spectrum = C(-c.c)(-c.c)
+Base.:-(c1::C, c::Number) where C<:Spectrum = C(c1.c .- c)
+Base.:-(c1::C, c2::C) where C<:Spectrum = C(c1.c .- c2.c)
+Base.:*(c1::C, c2::C) where C<:Spectrum = C(c1.c .* c2.c)
+Base.:*(c1::C, f::Number) where C<:Spectrum = C(c1.c .* f)
+Base.:*(f::Number, c1::C) where C<:Spectrum = C(c1.c .* f)
+Base.:/(c1::C, c2::C) where C<:Spectrum = C(c1.c ./ c2.c)
+Base.:/(c1::C, f::Number) where C<:Spectrum = C(c1.c ./ f)
+Base.sqrt(c::C) where C<:Spectrum = C(sqrt.(c.c))
+Base.:^(c::C, e::Number) where C<:Spectrum = C(c.c .^ e)
+Base.exp(c::C) where C<:Spectrum = C(exp.(c.c))
+lerp(c1::C, c2::C, t::Float32) where C<:Spectrum = (1f0 - t) * c1 + t * c2
 
-Base.getindex(c::C, i) where C <: Spectrum = c.c[i]
+Base.getindex(c::C, i) where C<:Spectrum = c.c[i]
 
 function Base.clamp(
     c::C, low::Float32 = 0f0, high::Float32 = Inf32,
-) where C <: Spectrum
+) where C<:Spectrum
     C(clamp.(c.c, low, high))
 end
 
-function Base.isnan(c::C) where C <: Spectrum
+function Base.isnan(c::C) where C<:Spectrum
     for v in c.c
         isnan(v) && return true
     end
     false
 end
 
-function Base.isinf(c::C) where C <: Spectrum
+function Base.isinf(c::C) where C<:Spectrum
     for v in c.c
         isinf(v) && return true
     end
     false
 end
 
-is_black(c::C) where C <: Spectrum = c.c |> iszero
+is_black(c::C) where C<:Spectrum = iszero(c.c)
 
 struct RGBSpectrum <: Spectrum
     c::Point3f
@@ -60,10 +60,10 @@ end
 RGBSpectrum(v::Float32 = 0f0) = RGBSpectrum(Point3f(v))
 RGBSpectrum(r, g, b) = RGBSpectrum(Point3f(r, g, b))
 
-to_XYZ(s::RGBSpectrum) = s.c |> RGB_to_XYZ
+to_XYZ(s::RGBSpectrum) = RGB_to_XYZ(s.c)
 @inbounds function to_Y(s::RGBSpectrum)::Float32
     0.212671f0 * s.c[1] + 0.715160f0 * s.c[2] + 0.072169f0 * s.c[3]
 end
 function from_XYZ(::Type{RGBSpectrum}, xyz::Point3f)
-    xyz |> XYZ_to_RGB |> RGBSpectrum
+    RGBSpectrum(XYZ_to_RGB(xyz))
 end

--- a/src/textures/basic.jl
+++ b/src/textures/basic.jl
@@ -1,15 +1,15 @@
-const TextureType = Union{Float32, S} where S <: Spectrum
+const TextureType = Union{Float32,S} where S<:Spectrum
 abstract type Texture end
 
-struct ConstantTexture{T <: TextureType} <: Texture
+struct ConstantTexture{T<:TextureType} <: Texture
     value::T
 end
 
-function (c::ConstantTexture{T})(si::SurfaceInteraction)::T where T <: TextureType
+function (c::ConstantTexture{T})(si::SurfaceInteraction)::T where T<:TextureType
     c.value
 end
 
-struct ScaleTexture{T <: Texture} <: Texture
+struct ScaleTexture{T<:Texture} <: Texture
     texture_1::T
     texture_2::T
 end
@@ -23,18 +23,18 @@ end
 but `mix` should be a texture that returns floating-point value
 that is used to interpolate between the first two.
 """
-struct MixTexture{T <: Texture, S <: Texture} <: Texture
+struct MixTexture{T<:Texture,S<:Texture} <: Texture
     texture_1::T
     texture_2::T
     mix::S
 end
 
 function (m::MixTexture)(si::SurfaceInteraction)
-    t::Float32 = si |> m.mix
+    t::Float32 = m.mix(si)
     (1 - t) * m.texture_1(si) + t * m.texture_2(si)
 end
 
-struct BilerpTexture{T <: Texture, M <: Mapping2D} <: Texture
+struct BilerpTexture{T<:Texture,M<:Mapping2D} <: Texture
     mapping::M
     v00::T
     v01::T

--- a/src/textures/mapping.jl
+++ b/src/textures/mapping.jl
@@ -29,7 +29,7 @@ pixel `x` & `y` coordinates.
         Texture coordinates at the shading point, estimated changes
         in `(s, t)` w.r.t. pixel `x` & `y` coordinates.
 """
-function map(m::UVMapping2D, si::SurfaceInteraction)::Tuple{Point2f, Vec2f, Vec2f}
+function map(m::UVMapping2D, si::SurfaceInteraction)::Tuple{Point2f,Vec2f,Vec2f}
     ∂st∂x = Vec2f(m.su * si.∂u∂x, m.sv * si.∂v∂x)
     ∂st∂y = Vec2f(m.su * si.∂u∂y, m.sv * si.∂v∂y)
     t = Point2f(m.su * si.uv[1] + m.du, m.sv * si.uv[2] + m.dv)
@@ -50,9 +50,9 @@ struct TransformMapping3D <: Mapping3D
     world_to_texture::Transformation
 end
 
-function map(m::TransformMapping3D, si::SurfaceInteraction)::Tuple{Point3f, Vec3f, Vec3f}
-    ∂p∂x = si.∂p∂x |> m.world_to_texture
-    ∂p∂y = si.∂p∂y |> m.world_to_texture
-    t = si.core.p |> m.world_to_texture
+function map(m::TransformMapping3D, si::SurfaceInteraction)::Tuple{Point3f,Vec3f,Vec3f}
+    ∂p∂x = m.world_to_texture(si.∂p∂x)
+    ∂p∂y = m.world_to_texture(si.∂p∂y)
+    t = m.world_to_texture(si.core.p)
     t, ∂p∂x, ∂p∂y
 end

--- a/src/transformations.jl
+++ b/src/transformations.jl
@@ -4,10 +4,10 @@ struct Transformation
 end
 
 Transformation() = Transformation(Mat4f(I), Mat4f(I))
-Transformation(m::Mat4f) = Transformation(m, m |> inv)
+Transformation(m::Mat4f) = Transformation(m, inv(m))
 is_identity(t::Transformation) = t.m == I && t.inv_m == I
 function Base.transpose(t::Transformation)
-    Transformation(t.m |> transpose, t.inv_m |> transpose)
+    Transformation(transpose(t.m), transpose(t.inv_m))
 end
 Base.inv(t::Transformation) = Transformation(t.inv_m, t.m)
 
@@ -22,98 +22,98 @@ function Base.:*(t1::Transformation, t2::Transformation)
 end
 
 function translate(δ::Vec3f)
-    m = Mat4f(
+    m = transpose(Mat4f(
         1, 0, 0, δ[1],
         0, 1, 0, δ[2],
         0, 0, 1, δ[3],
         0, 0, 0, 1,
-    ) |> transpose
-    m_inv = Mat4f(
+    ))
+    m_inv = transpose(Mat4f(
         1, 0, 0, -δ[1],
         0, 1, 0, -δ[2],
         0, 0, 1, -δ[3],
         0, 0, 0, 1,
-    ) |> transpose
+    ))
     Transformation(m, m_inv)
 end
 
 function scale(x::Number, y::Number, z::Number)
-    m = Mat4f(
+    m = transpose(Mat4f(
         x, 0, 0, 0,
         0, y, 0, 0,
         0, 0, z, 0,
         0, 0, 0, 1,
-    ) |> transpose
-    m_inv = Mat4f(
+    ))
+    m_inv = transpose(Mat4f(
         1 / x, 0, 0, 0,
         0, 1 / y, 0, 0,
         0, 0, 1 / z, 0,
         0, 0, 0, 1,
-    ) |> transpose
+    ))
     Transformation(m, m_inv)
 end
 
 function rotate_x(θ::Float32)
-    sin_θ = θ |> deg2rad |> sin
-    cos_θ = θ |> deg2rad |> cos
-    m = Mat4f(
+    sin_θ = sin(deg2rad(θ))
+    cos_θ = cos(deg2rad(θ))
+    m = transpose(Mat4f(
         1, 0, 0, 0,
         0, cos_θ, -sin_θ, 0,
         0, sin_θ, cos_θ, 0,
         0, 0, 0, 1,
-    ) |> transpose
-    Transformation(m, m |> transpose)
+    ))
+    Transformation(m, transpose(m))
 end
 
 function rotate_y(θ::Float32)
-    sin_θ = θ |> deg2rad |> sin
-    cos_θ = θ |> deg2rad |> cos
-    m = Mat4f(
+    sin_θ = sin(deg2rad(θ))
+    cos_θ = cos(deg2rad(θ))
+    m = transpose(Mat4f(
         cos_θ, 0, sin_θ, 0,
         0, 1, 0, 0,
         -sin_θ, 0, cos_θ, 0,
         0, 0, 0, 1,
-    ) |> transpose
-    Transformation(m, m |> transpose)
+    ))
+    Transformation(m, transpose(m))
 end
 
 function rotate_z(θ::Float32)
-    sin_θ = θ |> deg2rad |> sin
-    cos_θ = θ |> deg2rad |> cos
-    m = Mat4f(
+    sin_θ = sin(deg2rad(θ))
+    cos_θ = cos(deg2rad(θ))
+    m = transpose(Mat4f(
         cos_θ, -sin_θ, 0, 0,
         sin_θ, cos_θ, 0, 0,
         0, 0, 1, 0,
         0, 0, 0, 1,
-    ) |> transpose
-    Transformation(m, m |> transpose)
+    ))
+    Transformation(m, transpose(m))
 end
 
 function rotate(θ::Float32, axis::Vec3f)
-    a = axis |> normalize
-    sin_θ = θ |> deg2rad |> sin
-    cos_θ = θ |> deg2rad |> cos
-    m = Mat4f(
+    a = normalize(axis)
+    sin_θ = sin(deg2rad(θ))
+    cos_θ = cos(deg2rad(θ))
+    m = transpose(Mat4f(
         a[1] * a[1] + (1 - a[1] * a[1]) * cos_θ, a[1] * a[2] * (1 - cos_θ) - a[3] * sin_θ, a[1] * a[3] * (1 - cos_θ) + a[2] * sin_θ, 0,
         a[1] * a[2] * (1 - cos_θ) + a[3] * sin_θ, a[2] * a[2] + (1 - a[2] * a[2]) * cos_θ, a[2] * a[3] * (1 - cos_θ) - a[1] * sin_θ, 0,
         a[1] * a[3] * (1 - cos_θ) - a[2] * sin_θ, a[2] * a[3] * (1 - cos_θ) + a[1] * sin_θ, a[3] * a[3] + (1 - a[3] * a[3]) * cos_θ, 0,
         0, 0, 0, 1,
-    ) |> transpose
-    Transformation(m, m |> transpose)
+    ))
+    Transformation(m, transpose(m))
 end
 
 function look_at(position::Point3f, target::Point3f, up::Vec3f)
-    z_axis = (position - target) |> normalize
-    x_axis = (up × z_axis) |> normalize
+    z_axis = normalize((position - target))
+    x_axis = normalize((up × z_axis))
     y_axis = z_axis × x_axis
 
-    m = Mat4f(
+    m = transpose(Mat4f(
         x_axis[1], y_axis[1], z_axis[1], 0,
         x_axis[2], y_axis[2], z_axis[2], 0,
         x_axis[3], y_axis[3], z_axis[3], 0,
         0, 0, 0, 1,
-    ) |> transpose
-    translate(Vec3f(position)) * Transformation(m, m |> transpose)
+    ))
+    translate(Vec3f(position)) * Transformation(m, transpose(m))
 end
 
 function perspective(fov::Float32, near::Float32, far::Float32)
@@ -139,24 +139,24 @@ end
 (t::Transformation)(v::Vec3f)::Vec3f = t.m[1:3, 1:3] * v
 (t::Transformation)(n::Normal3f)::Normal3f = transpose(t.inv_m[1:3, 1:3]) * n
 function (t::Transformation)(b::Bounds3)
-    mapreduce(i -> corner(b, i) |> t |> Bounds3, ∪, 1:8)
+    mapreduce(i -> Bounds3(t(corner(b, i))), ∪, 1:8)
 end
-(t::Transformation)(r::Ray) = Ray(r.o |> t, r.d |> t, r.t_max, r.time)
+(t::Transformation)(r::Ray) = Ray(t(r.o), t(r.d), r.t_max, r.time)
 function (t::Transformation)(rd::RayDifferentials)
     RayDifferentials(
-        rd.o |> t, rd.d |> t, rd.t_max, rd.time,
+        t(rd.o), t(rd.d), rd.t_max, rd.time,
         rd.has_differentials,
-        rd.rx_origin |> t,
-        rd.ry_origin |> t,
-        rd.rx_direction |> t,
-        rd.ry_direction |> t,
+        t(rd.rx_origin),
+        t(rd.ry_origin),
+        t(rd.rx_direction),
+        t(rd.ry_direction),
     )
 end
 
 function has_scale(t::Transformation)
-    a = Vec3f(1, 0, 0) |> t |> norm
-    b = Vec3f(0, 1, 0) |> t |> norm
-    c = Vec3f(0, 0, 1) |> t |> norm
+    a = norm(t(Vec3f(1, 0, 0)))
+    b = norm(t(Vec3f(0, 1, 0)))
+    c = norm(t(Vec3f(0, 0, 1)))
     a ≉ 1 || b ≉ 1 || c ≉ 1
 end
 
@@ -171,7 +171,7 @@ end
 
 Quaternion() = Quaternion(Vec3f(0f0), 1f0)
 function Quaternion(t::Transformation)
-    trace = t.m[1:3, 1:3] |> tr
+    trace = tr(t.m[1:3, 1:3])
     if trace > 0f0
         # Compute w from matrix trace, then xyz.
         # 4w^2 = m[0, 0] + m[1, 1] + m[2, 2] + m[3, 3] => (m[3, 3] == 1)
@@ -230,14 +230,14 @@ function Transformation(q::Quaternion)
         2 * (xz + wy), 2 * (yz - wx), 1 - 2 * (xx + yy), 0,
         0, 0, 0, 1,
     )
-    Transformation(m, m |> transpose)
+    Transformation(m, transpose(m))
 end
 
 function slerp(q1::Quaternion, q2::Quaternion, t::Float32)
     cos_θ = q1 ⋅ q2
     cos_θ > 0.9995f0 && return normalize((1 - t) * q1 + t * q2)
 
-    θ = cos_θ |> acos
+    θ = acos(cos_θ)
     θ_p = θ * t
     q_perp = normalize(q2 - q1 * cos_θ)
     q1 * cos(θ_p) + q_perp * sin(θ_p)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,7 +35,7 @@ end
     core = Trace.ShapeCore(Trace.translate(Vec3f(0)), false)
     s = Trace.Sphere(core, 1f0, -1f0, 1f0, 360f0)
 
-    sb = s |> Trace.object_bound
+    sb = Trace.object_bound(s)
     @test sb[1] == Point3f(-1f0)
     @test sb[2] == Point3f(1f0)
 end

--- a/test/test_intersection.jl
+++ b/test/test_intersection.jl
@@ -1,9 +1,9 @@
 @testset "Ray-Bounds intersection" begin
     b = Trace.Bounds3(Point3f(1), Point3f(2))
     b_neg = Trace.Bounds3(Point3f(-2), Point3f(-1))
-    r0 = Trace.Ray(o=Point3f(0), d=Vec3f(1, 0, 0))
-    r1 = Trace.Ray(o=Point3f(0), d=Vec3f(1))
-    ri = Trace.Ray(o=Point3f(1.5), d=Vec3f(1, 1, 0))
+    r0 = Trace.Ray(o = Point3f(0), d = Vec3f(1, 0, 0))
+    r1 = Trace.Ray(o = Point3f(0), d = Vec3f(1))
+    ri = Trace.Ray(o = Point3f(1.5), d = Vec3f(1, 1, 0))
 
     r, t0, t1 = Trace.intersect(b, r1)
     @test r && t0 ≈ 1f0 && t1 ≈ 2f0
@@ -14,7 +14,7 @@
 
     # Test intersection with precomputed direction reciprocal.
     inv_dir = 1f0 ./ r1.d
-    dir_is_negative = r1.d |> Trace.is_dir_negative
+    dir_is_negative = Trace.is_dir_negative(r1.d)
     @test Trace.intersect_p(b, r1, inv_dir, dir_is_negative)
     @test !Trace.intersect_p(b_neg, r1, inv_dir, dir_is_negative)
 end
@@ -24,7 +24,7 @@ end
     core = Trace.ShapeCore(Trace.Transformation(), false)
     s = Trace.Sphere(core, 1f0, 360f0)
 
-    r = Trace.Ray(o=Point3f(0, -2, 0), d=Vec3f(0, 1, 0))
+    r = Trace.Ray(o = Point3f(0, -2, 0), d = Vec3f(0, 1, 0))
     i, t, interaction = Trace.intersect(s, r, false)
     ip = Trace.intersect_p(s, r, false)
     @test i == ip
@@ -42,7 +42,7 @@ end
     i, t, interaction = Trace.intersect(s, spawned_ray, false)
     @test !i
 
-    r = Trace.Ray(o=Point3f(0, 0, -2), d=Vec3f(0, 0, 1))
+    r = Trace.Ray(o = Point3f(0, 0, -2), d = Vec3f(0, 0, 1))
     i, t, interaction = Trace.intersect(s, r, false)
     ip = Trace.intersect_p(s, r, false)
     @test i == ip
@@ -54,7 +54,7 @@ end
     @test norm(interaction.shading.n) ≈ 1f0
 
     # Test ray inside a sphere.
-    r0 = Trace.Ray(o=Point3f(0), d=Vec3f(0, 1, 0))
+    r0 = Trace.Ray(o = Point3f(0), d = Vec3f(0, 1, 0))
     i, t, interaction = Trace.intersect(s, r0, false)
     @test i
     @test t ≈ 1f0
@@ -64,7 +64,7 @@ end
     @test norm(interaction.shading.n) ≈ 1f0
 
     # Test ray at the edge of the sphere.
-    ray_at_edge = Trace.Ray(o=Point3f(0, -1, 0), d=Vec3f(0, -1, 0))
+    ray_at_edge = Trace.Ray(o = Point3f(0, -1, 0), d = Vec3f(0, -1, 0))
     i, t, interaction = Trace.intersect(s, ray_at_edge, false)
     @test i
     @test t ≈ 0f0
@@ -75,7 +75,7 @@ end
     # Translated sphere.
     core = Trace.ShapeCore(Trace.translate(Vec3f(0, 2, 0)), false)
     s = Trace.Sphere(core, 1f0, 360f0)
-    r = Trace.Ray(o=Point3f(0, 0, 0), d=Vec3f(0, 1, 0))
+    r = Trace.Ray(o = Point3f(0, 0, 0), d = Vec3f(0, 1, 0))
 
     i, t, interaction = Trace.intersect(s, r, false)
     ip = Trace.intersect_p(s, r, false)
@@ -95,8 +95,8 @@ end
         [Trace.Normal3f(0, 0, -1), Trace.Normal3f(0, 0, -1), Trace.Normal3f(0, 0, -1)],
     )
 
-    tv = triangles[1] |> Trace.vertices
-    a = norm(tv[1] - tv[2]) ^ 2 * 0.5f0
+    tv = Trace.vertices(triangles[1])
+    a = norm(tv[1] - tv[2])^2 * 0.5f0
     @test Trace.area(triangles[1]) ≈ a
 
     target_wb = Trace.Bounds3(Point3f(0, 0, 2), Point3f(1, 1, 2))
@@ -105,7 +105,7 @@ end
     @test Trace.world_bound(triangles[1]) ≈ target_wb
 
     # Test ray intersection.
-    ray = Trace.Ray(o=Point3f(0, 0, -2), d=Vec3f(0, 0, 1))
+    ray = Trace.Ray(o = Point3f(0, 0, -2), d = Vec3f(0, 0, 1))
     intersects_p = Trace.intersect_p(triangles[1], ray)
     intersects, t_hit, interaction = Trace.intersect(triangles[1], ray)
     @test intersects_p == intersects == true
@@ -115,7 +115,7 @@ end
     @test interaction.core.n ≈ Trace.Normal3f(0, 0, -1)
     @test interaction.core.wo ≈ -ray.d
     # Test ray intersection (lower-left corner).
-    ray = Trace.Ray(o=Point3f(1, 0.5, 0), d=Vec3f(0, 0, 1))
+    ray = Trace.Ray(o = Point3f(1, 0.5, 0), d = Vec3f(0, 0, 1))
     intersects_p = Trace.intersect_p(triangles[1], ray)
     intersects, t_hit, interaction = Trace.intersect(triangles[1], ray)
     @test intersects_p == intersects == true
@@ -139,8 +139,8 @@ end
     @test Trace.world_bound(bvh) ≈ Trace.Bounds3(Point3f(-1f0), Point3f(10f0, 10f0, 1f0))
     @test Trace.world_bound(bvh2) ≈ Trace.Bounds3(Point3f(-1f0), Point3f(22f0, 22f0, 1f0))
 
-    ray1 = Trace.Ray(o=Point3f(-2f0, 0f0, 0f0), d=Vec3f(1f0, 0f0, 0f0))
-    ray2 = Trace.Ray(o=Point3f(0f0, 18f0, 0f0), d=Vec3f(1f0, 0f0, 0f0))
+    ray1 = Trace.Ray(o = Point3f(-2f0, 0f0, 0f0), d = Vec3f(1f0, 0f0, 0f0))
+    ray2 = Trace.Ray(o = Point3f(0f0, 18f0, 0f0), d = Vec3f(1f0, 0f0, 0f0))
 
     intersects, interaction = Trace.intersect!(bvh2, ray1)
     @test intersects
@@ -175,19 +175,19 @@ end
         Point3f(-4, -4, -1), Point3f(4, 4, 15),
     )
 
-    ray = Trace.Ray(o=Point3f(0, 0, -2), d=Vec3f(0, 0, 1))
+    ray = Trace.Ray(o = Point3f(0, 0, -2), d = Vec3f(0, 0, 1))
     intersects, interaction = Trace.intersect!(bvh, ray)
     @test intersects
     @test ray.t_max ≈ 1f0
     @test ray(ray.t_max) ≈ interaction.core.p
 
-    ray = Trace.Ray(o=Point3f(1.5, 0, -2), d=Vec3f(0, 0, 1))
+    ray = Trace.Ray(o = Point3f(1.5, 0, -2), d = Vec3f(0, 0, 1))
     intersects, interaction = Trace.intersect!(bvh, ray)
     @test intersects
     @test 2f0 < ray.t_max < 6f0
     @test ray(ray.t_max) ≈ interaction.core.p
 
-    ray = Trace.Ray(o=Point3f(3, 0, -2), d=Vec3f(0, 0, 1))
+    ray = Trace.Ray(o = Point3f(3, 0, -2), d = Vec3f(0, 0, 1))
     intersects, interaction = Trace.intersect!(bvh, ray)
     @test intersects
     @test 7f0 < ray.t_max < 15f0


### PR DESCRIPTION
The piping operators quite badly clutter the profiling and, if it doesn't inline for some reason, also creates allocations and performance problems.
I tried to convince JuliaFormatter to be as little destructive as possible, but I could only get it to not change _as much_.