### PR TITLE
move access out of loop

### DIFF
--- a/src/integrators/sppm.jl
+++ b/src/integrators/sppm.jl
@@ -329,6 +329,8 @@ function _trace_photons!(
     bar = get_progress_bar(
         i.photons_per_iteration, "[$iteration] Photon pass: ",
     )
+    shutter_open = i.camera.core.core.shutter_open
+    shutter_close = i.camera.core.core.shutter_close
     Threads.@threads for photon_index in 0:i.photons_per_iteration - 1
         # Follow photon path for `photon_index`.
         halton_index = halton_base + photon_index
@@ -350,8 +352,8 @@ function _trace_photons!(
             radical_inverse(halton_dim + 3, halton_index),
         )
         u_light_time = lerp(
-            i.camera.core.core.shutter_open,
-            i.camera.core.core.shutter_close,
+            shutter_open,
+            shutter_close,
             radical_inverse(halton_dim + 4, halton_index),
         )
         halton_dim += 5


### PR DESCRIPTION
# Master
5.307263 seconds (251.33 M allocations: 15.794 GiB, 53.87% gc time, 356360 lock conflicts)
# loop unhoisting
4.576385 seconds (240.86 M allocations: 11.708 GiB, 49.78% gc time, 455456 lock conflicts)