### PR TITLE
Fix Sobol sampler and D65 illuminant for Metal GPU backend

### DIFF
--- a/src/random/sobol.jl
+++ b/src/random/sobol.jl
@@ -117,18 +117,13 @@ Arguments:
 - dimension: Sobol dimension (0-based, max NSOBOL_DIMENSIONS-1)
 - scramble_seed: Seed for FastOwen scrambling
 - sobol_matrices: The Sobol generator matrices array (must be GPU-accessible)
-
-Uses compile-time unrolled loop with branchless bitwise operations for SPIR-V compatibility.
 """
 @inline function sobol_sample(a::Int64, dimension::Int32, scramble_seed::UInt32, sobol_matrices)::Float32
     # Compute Sobol sample via generator matrix multiplication (XOR)
     v = UInt32(0)
     base_i = dimension * SOBOL_MATRIX_SIZE + Int32(1)  # Julia is 1-indexed
 
-    # Compile-time unrolled loop (52 iterations for SOBOL_MATRIX_SIZE)
-    # Uses pure branchless bitwise operations for SPIR-V structured control flow
-    Base.Cartesian.@nexprs 52 bit -> begin
-        bit0 = Int32(bit) - Int32(1)
+    for bit0 in Int32(0):Int32(SOBOL_MATRIX_SIZE - 1)
         # Extract bit from 'a': either 0 or 1
         bit_val = UInt32((a >> bit0) & Int64(1))
         # Create mask: 0xffffffff if bit set, 0x00000000 otherwise
@@ -139,7 +134,6 @@ Uses compile-time unrolled loop with branchless bitwise operations for SPIR-V co
 
     # Apply FastOwen scrambling for decorrelation
     v = fast_owen_scramble(v, scramble_seed)
-
     # Convert to [0, 1) float
     return min(Float32(v) * FLOAT32_SCALE, ONE_MINUS_EPSILON)
 end
@@ -167,35 +161,24 @@ end
 # ZSobol sampler (matching pbrt-v4/src/pbrt/samplers.h ZSobolSampler)
 # =============================================================================
 
-# 24 permutations of base-4 digits (0,1,2,3)
-# Using Tuple{Tuple{...}} so it works as a compile-time constant on GPU
+# 24 permutations of base-4 digits (0,1,2,3), bit-packed into UInt32 values.
+# Each UInt32 encodes one permutation: digit d is at bits [2d+1:2d].
+# Lookup: (packed >> (digit * 2)) & 3
+# These are appended to the Sobol matrices array for GPU-safe runtime indexing
+# (tuple indexing with runtime indices is broken on some GPU backends like Metal).
 # Reference: pbrt-v4/src/pbrt/samplers.h:303-330
-const PERMUTATIONS_4WAY = (
-    (UInt64(0), UInt64(1), UInt64(2), UInt64(3)),  # perm 0
-    (UInt64(0), UInt64(1), UInt64(3), UInt64(2)),  # perm 1
-    (UInt64(0), UInt64(2), UInt64(1), UInt64(3)),  # perm 2
-    (UInt64(0), UInt64(2), UInt64(3), UInt64(1)),  # perm 3
-    (UInt64(0), UInt64(3), UInt64(2), UInt64(1)),  # perm 4
-    (UInt64(0), UInt64(3), UInt64(1), UInt64(2)),  # perm 5
-    (UInt64(1), UInt64(0), UInt64(2), UInt64(3)),  # perm 6
-    (UInt64(1), UInt64(0), UInt64(3), UInt64(2)),  # perm 7
-    (UInt64(1), UInt64(2), UInt64(0), UInt64(3)),  # perm 8
-    (UInt64(1), UInt64(2), UInt64(3), UInt64(0)),  # perm 9
-    (UInt64(1), UInt64(3), UInt64(2), UInt64(0)),  # perm 10
-    (UInt64(1), UInt64(3), UInt64(0), UInt64(2)),  # perm 11
-    (UInt64(2), UInt64(1), UInt64(0), UInt64(3)),  # perm 12
-    (UInt64(2), UInt64(1), UInt64(3), UInt64(0)),  # perm 13
-    (UInt64(2), UInt64(0), UInt64(1), UInt64(3)),  # perm 14
-    (UInt64(2), UInt64(0), UInt64(3), UInt64(1)),  # perm 15
-    (UInt64(2), UInt64(3), UInt64(0), UInt64(1)),  # perm 16
-    (UInt64(2), UInt64(3), UInt64(1), UInt64(0)),  # perm 17
-    (UInt64(3), UInt64(1), UInt64(2), UInt64(0)),  # perm 18
-    (UInt64(3), UInt64(1), UInt64(0), UInt64(2)),  # perm 19
-    (UInt64(3), UInt64(2), UInt64(1), UInt64(0)),  # perm 20
-    (UInt64(3), UInt64(2), UInt64(0), UInt64(1)),  # perm 21
-    (UInt64(3), UInt64(0), UInt64(2), UInt64(1)),  # perm 22
-    (UInt64(3), UInt64(0), UInt64(1), UInt64(2)),  # perm 23
-)
+const PACKED_PERMUTATIONS_4WAY = UInt32[
+    0x000000e4, 0x000000b4, 0x000000d8, 0x00000078, # perms 0-3
+    0x0000006c, 0x0000009c, 0x000000e1, 0x000000b1, # perms 4-7
+    0x000000c9, 0x00000039, 0x0000002d, 0x0000008d, # perms 8-11
+    0x000000c6, 0x00000036, 0x000000d2, 0x00000072, # perms 12-15
+    0x0000004e, 0x0000001e, 0x00000027, 0x00000087, # perms 16-19
+    0x0000001b, 0x0000004b, 0x00000063, 0x00000093, # perms 20-23
+]
+
+# Offset of the packed permutation table within the combined matrices array.
+# The Sobol matrices occupy indices 1:N, the permutation table is at N+1:N+24.
+const PERM_TABLE_OFFSET = Int32(length(SobolMatrices32))
 
 # Branchless max for Int32 - avoids potential branching in max()
 @inline function branchless_max_i32(a::Int32, b::Int32)::Int32
@@ -206,31 +189,28 @@ const PERMUTATIONS_4WAY = (
     return b + (diff & ~mask)
 end
 
-# Direct permutation lookup from PERMUTATIONS_4WAY using tuple indexing
-# Returns the permuted digit for a given permutation index p (1-24) and digit (0-3)
-@inline function lookup_permutation(p::Int32, digit::Int32)::UInt64
-    # p is 1-indexed (1-24), digit is 0-indexed (0-3)
-    # Direct tuple indexing - GPU-safe with @inbounds
-    @inbounds perm_tuple = PERMUTATIONS_4WAY[p]
-    @inbounds return perm_tuple[digit + Int32(1)]
+# Permutation lookup from the packed permutation table stored in the matrices array.
+# p is 1-indexed (1-24), digit is 0-indexed (0-3).
+@inline function lookup_permutation(matrices, p::Int32, digit::Int32)::UInt64
+    @inbounds packed = matrices[PERM_TABLE_OFFSET + p]
+    return UInt64((packed >> (UInt32(digit) * UInt32(2))) & UInt32(3))
 end
 
 """
-    zsobol_get_sample_index(morton_index, dimension, log2_spp, n_base4_digits) -> UInt64
+    zsobol_get_sample_index(morton_index, dimension, log2_spp, n_base4_digits, matrices) -> UInt64
 
 Compute the permuted sample index for ZSobol sampling.
 Reference: pbrt-v4/src/pbrt/samplers.h ZSobolSampler::GetSampleIndex (lines 301-356)
 
 This applies random base-4 digit permutations to the Morton-encoded index,
 ensuring good sample distribution across pixels while maintaining low-discrepancy.
-
-Uses compile-time unrolled loop with branchless operations for SPIR-V compatibility.
 """
 @inline function zsobol_get_sample_index(
     morton_index::UInt64,
     dimension::Int32,
     log2_spp::Int32,
-    n_base4_digits::Int32
+    n_base4_digits::Int32,
+    matrices
 )::UInt64
     sample_index = UInt64(0)
 
@@ -239,9 +219,7 @@ Uses compile-time unrolled loop with branchless operations for SPIR-V compatibil
     last_digit = pow2_flag
     pow2_adjust = pow2_flag
 
-    # Compile-time unrolled loop (32 iterations covers up to 64-bit Morton codes)
-    Base.Cartesian.@nexprs 32 iter -> begin
-        iter0 = Int32(iter) - Int32(1)
+    for iter0 in Int32(0):Int32(31)
         i = n_base4_digits - Int32(1) - iter0
 
         # Branchless max to ensure digit_shift >= 0
@@ -257,7 +235,7 @@ Uses compile-time unrolled loop with branchless operations for SPIR-V compatibil
         p = u_int32((hash_val >> 24) % UInt64(24)) + Int32(1)  # 1-indexed
 
         # Branchless permutation lookup
-        permuted_digit = lookup_permutation(p, digit)
+        permuted_digit = lookup_permutation(matrices, p, digit)
 
         # Branchless conditional: only apply if i >= last_digit
         # Create mask: all 1s if i >= last_digit, all 0s otherwise
@@ -290,7 +268,7 @@ Generate a 1D Sobol sample for the given pixel and sample index.
 )::Float32
     # Convert pixel coords to UInt32 (px, py are always non-negative)
     morton_index = (encode_morton2(u_uint32(px), u_uint32(py)) << log2_spp) | u_uint64(sample_idx)
-    sobol_index = zsobol_get_sample_index(morton_index, dim, log2_spp, n_base4_digits)
+    sobol_index = zsobol_get_sample_index(morton_index, dim, log2_spp, n_base4_digits, sobol_matrices)
     # pbrt-v4 compatibility: Hash uses dimension AFTER increment (dim + 1 for 1D samples)
     # See pbrt-v4/src/pbrt/samplers.h ZSobolSampler::Get1D() lines 258-262
     # Uses MurmurHash64A on (dimension, seed) bytes, then truncates to 32-bit
@@ -311,7 +289,7 @@ Uses two consecutive Sobol dimensions with independent scrambling seeds.
 )::Tuple{Float32, Float32}
     # Convert pixel coords to UInt32 (px, py are always non-negative)
     morton_index = (encode_morton2(u_uint32(px), u_uint32(py)) << log2_spp) | u_uint64(sample_idx)
-    sobol_index = zsobol_get_sample_index(morton_index, dim, log2_spp, n_base4_digits)
+    sobol_index = zsobol_get_sample_index(morton_index, dim, log2_spp, n_base4_digits, sobol_matrices)
 
     # pbrt-v4 compatibility: Hash uses dimension AFTER increment (dim + 2 for 2D samples)
     # See pbrt-v4/src/pbrt/samplers.h ZSobolSampler::Get2D() lines 274-279
@@ -357,8 +335,11 @@ This struct can be passed directly to GPU kernels via Adapt.jl integration.
 All sampling state is computed on-the-fly from pixel coordinates and sample index,
 making it stateless and thread-safe.
 
+The matrices array contains both the Sobol generator matrices (indices 1:N)
+and the packed permutation table for ZSobol digit permutations (indices N+1:N+24).
+
 # Fields
-- `matrices::M`: GPU array of Sobol generator matrices (UInt32)
+- `matrices::M`: GPU array of Sobol generator matrices + packed permutations (UInt32)
 - `log2_spp::Int32`: log2 of samples per pixel
 - `n_base4_digits::Int32`: number of base-4 digits for Morton encoding
 - `seed::UInt32`: scrambling seed
@@ -386,9 +367,10 @@ Allocates Sobol matrices on the specified backend (CPU/GPU).
 - `samples_per_pixel`: Number of samples per pixel
 """
 function SobolRNG(backend, seed::UInt32, width::Integer, height::Integer, samples_per_pixel::Integer)
-    # Allocate and copy Sobol matrices to GPU
-    matrices = KA.allocate(backend, UInt32, length(SobolMatrices32))
-    KA.copyto!(backend, matrices, SobolMatrices32)
+    # Allocate and copy Sobol matrices + packed permutation table to GPU
+    combined = vcat(SobolMatrices32, PACKED_PERMUTATIONS_4WAY)
+    matrices = KA.allocate(backend, UInt32, length(combined))
+    KA.copyto!(backend, matrices, combined)
 
     # Compute ZSobol parameters
     log2_spp, n_base4_digits = compute_zsobol_params(Int(samples_per_pixel), Int(width), Int(height))

--- a/src/sampler/sobol.jl
+++ b/src/sampler/sobol.jl
@@ -107,24 +107,20 @@ Arguments:
 """
 @inline function sobol_sample(a::Int64, dimension::Int32, scramble_seed::UInt32, sobol_matrices)::Float32
     # Compute Sobol sample via generator matrix multiplication (XOR)
-    # Use fixed-count loop for GPU compatibility (max 52 bits = SOBOL_MATRIX_SIZE)
     v = UInt32(0)
     base_i = dimension * SOBOL_MATRIX_SIZE + Int32(1)  # Julia is 1-indexed
 
-    # Fully unrolled loop using @nexprs for SPIR-V structured control flow compatibility
-    # Each iteration: branchless XOR - always read matrix, mask with bit value
-    # Uses pure bitwise ops to avoid any conditional branches
-    Base.Cartesian.@nexprs 52 bit -> begin
-        bit0 = Int32(bit) - Int32(1)
-        # Extract bit and spread to all 32 bits: 0 if bit clear, 0xffffffff if bit set
+    for bit0 in Int32(0):Int32(SOBOL_MATRIX_SIZE - 1)
+        # Extract bit from 'a': either 0 or 1
         bit_val = UInt32((a >> bit0) & Int64(1))
-        mask = (bit_val * UInt32(0xffffffff))  # 0 or 0xffffffff
+        # Create mask: 0xffffffff if bit set, 0x00000000 otherwise
+        mask = bit_val * UInt32(0xffffffff)
+        # XOR with masked matrix value (branchless conditional)
         @inbounds v ⊻= sobol_matrices[base_i + bit0] & mask
     end
 
     # Apply FastOwen scrambling for decorrelation
     v = fast_owen_scramble(v, scramble_seed)
-
     # Convert to [0, 1) float
     return min(Float32(v) * FLOAT32_SCALE, ONE_MINUS_EPSILON)
 end
@@ -152,35 +148,24 @@ end
 # ZSobol sampler (matching pbrt-v4/src/pbrt/samplers.h ZSobolSampler)
 # =============================================================================
 
-# 24 permutations of base-4 digits (0,1,2,3)
-# Using Tuple{Tuple{...}} so it works as a compile-time constant on GPU
+# 24 permutations of base-4 digits (0,1,2,3), bit-packed into UInt32 values.
+# Each UInt32 encodes one permutation: digit d is at bits [2d+1:2d].
+# Lookup: (packed >> (digit * 2)) & 3
+# Stored in a GPU array (appended to sobol_matrices) because runtime tuple
+# indexing is broken on the Metal GPU backend.
 # Reference: pbrt-v4/src/pbrt/samplers.h:303-330
-const PERMUTATIONS_4WAY = (
-    (UInt64(0), UInt64(1), UInt64(2), UInt64(3)),  # perm 0
-    (UInt64(0), UInt64(1), UInt64(3), UInt64(2)),  # perm 1
-    (UInt64(0), UInt64(2), UInt64(1), UInt64(3)),  # perm 2
-    (UInt64(0), UInt64(2), UInt64(3), UInt64(1)),  # perm 3
-    (UInt64(0), UInt64(3), UInt64(2), UInt64(1)),  # perm 4
-    (UInt64(0), UInt64(3), UInt64(1), UInt64(2)),  # perm 5
-    (UInt64(1), UInt64(0), UInt64(2), UInt64(3)),  # perm 6
-    (UInt64(1), UInt64(0), UInt64(3), UInt64(2)),  # perm 7
-    (UInt64(1), UInt64(2), UInt64(0), UInt64(3)),  # perm 8
-    (UInt64(1), UInt64(2), UInt64(3), UInt64(0)),  # perm 9
-    (UInt64(1), UInt64(3), UInt64(2), UInt64(0)),  # perm 10
-    (UInt64(1), UInt64(3), UInt64(0), UInt64(2)),  # perm 11
-    (UInt64(2), UInt64(1), UInt64(0), UInt64(3)),  # perm 12
-    (UInt64(2), UInt64(1), UInt64(3), UInt64(0)),  # perm 13
-    (UInt64(2), UInt64(0), UInt64(1), UInt64(3)),  # perm 14
-    (UInt64(2), UInt64(0), UInt64(3), UInt64(1)),  # perm 15
-    (UInt64(2), UInt64(3), UInt64(0), UInt64(1)),  # perm 16
-    (UInt64(2), UInt64(3), UInt64(1), UInt64(0)),  # perm 17
-    (UInt64(3), UInt64(1), UInt64(2), UInt64(0)),  # perm 18
-    (UInt64(3), UInt64(1), UInt64(0), UInt64(2)),  # perm 19
-    (UInt64(3), UInt64(2), UInt64(1), UInt64(0)),  # perm 20
-    (UInt64(3), UInt64(2), UInt64(0), UInt64(1)),  # perm 21
-    (UInt64(3), UInt64(0), UInt64(2), UInt64(1)),  # perm 22
-    (UInt64(3), UInt64(0), UInt64(1), UInt64(2)),  # perm 23
-)
+const PACKED_PERMUTATIONS_4WAY = UInt32[
+    0x000000e4, 0x000000b4, 0x000000d8, 0x00000078, # perms 0-3
+    0x0000006c, 0x0000009c, 0x000000e1, 0x000000b1, # perms 4-7
+    0x000000c9, 0x00000039, 0x0000002d, 0x0000008d, # perms 8-11
+    0x000000c6, 0x00000036, 0x000000d2, 0x00000072, # perms 12-15
+    0x0000004e, 0x0000001e, 0x00000027, 0x00000087, # perms 16-19
+    0x0000001b, 0x0000004b, 0x00000063, 0x00000093, # perms 20-23
+]
+
+# Offset of the packed permutation table within the combined matrices array.
+# The Sobol matrices occupy indices 1:N, the permutation table is at N+1:N+24.
+const PERM_TABLE_OFFSET = Int32(length(SobolMatrices32))
 
 # Branchless max for Int32 - avoids potential branching in max()
 @inline function branchless_max_i32(a::Int32, b::Int32)::Int32
@@ -191,31 +176,28 @@ const PERMUTATIONS_4WAY = (
     return b + (diff & ~mask)
 end
 
-# Direct permutation lookup from PERMUTATIONS_4WAY using tuple indexing
-# Returns the permuted digit for a given permutation index p (1-24) and digit (0-3)
-@inline function lookup_permutation(p::Int32, digit::Int32)::UInt64
-    # p is 1-indexed (1-24), digit is 0-indexed (0-3)
-    # Direct tuple indexing - GPU-safe with @inbounds
-    @inbounds perm_tuple = PERMUTATIONS_4WAY[p]
-    @inbounds return perm_tuple[digit + Int32(1)]
+# Permutation lookup from the packed permutation table stored in the matrices array.
+# p is 1-indexed (1-24), digit is 0-indexed (0-3).
+@inline function lookup_permutation(matrices, p::Int32, digit::Int32)::UInt64
+    @inbounds packed = matrices[PERM_TABLE_OFFSET + p]
+    return UInt64((packed >> (UInt32(digit) * UInt32(2))) & UInt32(3))
 end
 
 """
-    zsobol_get_sample_index(morton_index, dimension, log2_spp, n_base4_digits) -> UInt64
+    zsobol_get_sample_index(morton_index, dimension, log2_spp, n_base4_digits, matrices) -> UInt64
 
 Compute the permuted sample index for ZSobol sampling.
 Reference: pbrt-v4/src/pbrt/samplers.h ZSobolSampler::GetSampleIndex (lines 301-356)
 
 This applies random base-4 digit permutations to the Morton-encoded index,
 ensuring good sample distribution across pixels while maintaining low-discrepancy.
-
-Uses compile-time unrolled loop with branchless operations for SPIR-V compatibility.
 """
 @inline function zsobol_get_sample_index(
     morton_index::UInt64,
     dimension::Int32,
     log2_spp::Int32,
-    n_base4_digits::Int32
+    n_base4_digits::Int32,
+    matrices
 )::UInt64
     sample_index = UInt64(0)
 
@@ -224,9 +206,7 @@ Uses compile-time unrolled loop with branchless operations for SPIR-V compatibil
     last_digit = pow2_flag
     pow2_adjust = pow2_flag
 
-    # Compile-time unrolled loop (32 iterations covers up to 64-bit Morton codes)
-    Base.Cartesian.@nexprs 32 iter -> begin
-        iter0 = Int32(iter) - Int32(1)
+    for iter0 in Int32(0):Int32(31)
         i = n_base4_digits - Int32(1) - iter0
 
         # Branchless max to ensure digit_shift >= 0
@@ -242,7 +222,7 @@ Uses compile-time unrolled loop with branchless operations for SPIR-V compatibil
         p = u_int32((hash_val >> 24) % UInt64(24)) + Int32(1)  # 1-indexed
 
         # Branchless permutation lookup
-        permuted_digit = lookup_permutation(p, digit)
+        permuted_digit = lookup_permutation(matrices, p, digit)
 
         # Branchless conditional: only apply if i >= last_digit
         # Create mask: all 1s if i >= last_digit, all 0s otherwise
@@ -275,7 +255,7 @@ Generate a 1D Sobol sample for the given pixel and sample index.
 )::Float32
     # Convert pixel coords to UInt32 (px, py are always non-negative)
     morton_index = (encode_morton2(u_uint32(px), u_uint32(py)) << log2_spp) | u_uint64(sample_idx)
-    sobol_index = zsobol_get_sample_index(morton_index, dim, log2_spp, n_base4_digits)
+    sobol_index = zsobol_get_sample_index(morton_index, dim, log2_spp, n_base4_digits, sobol_matrices)
     # pbrt-v4 compatibility: Hash uses dimension AFTER increment (dim + 1 for 1D samples)
     # See pbrt-v4/src/pbrt/samplers.h ZSobolSampler::Get1D() lines 258-262
     # Uses MurmurHash64A on (dimension, seed) bytes, then truncates to 32-bit
@@ -296,7 +276,7 @@ Uses two consecutive Sobol dimensions with independent scrambling seeds.
 )::Tuple{Float32, Float32}
     # Convert pixel coords to UInt32 (px, py are always non-negative)
     morton_index = (encode_morton2(u_uint32(px), u_uint32(py)) << log2_spp) | u_uint64(sample_idx)
-    sobol_index = zsobol_get_sample_index(morton_index, dim, log2_spp, n_base4_digits)
+    sobol_index = zsobol_get_sample_index(morton_index, dim, log2_spp, n_base4_digits, sobol_matrices)
 
     # pbrt-v4 compatibility: Hash uses dimension AFTER increment (dim + 2 for 2D samples)
     # See pbrt-v4/src/pbrt/samplers.h ZSobolSampler::Get2D() lines 274-279
@@ -342,8 +322,12 @@ This struct can be passed directly to GPU kernels via Adapt.jl integration.
 All sampling state is computed on-the-fly from pixel coordinates and sample index,
 making it stateless and thread-safe.
 
+The matrices array contains both the Sobol generator matrices (indices 1:N)
+and the packed permutation table for ZSobol digit permutations (indices N+1:N+24).
+This avoids runtime tuple indexing which is broken on some GPU backends (e.g. Metal).
+
 # Fields
-- `matrices::M`: GPU array of Sobol generator matrices (UInt32)
+- `matrices::M`: GPU array of Sobol generator matrices + packed permutations (UInt32)
 - `log2_spp::Int32`: log2 of samples per pixel
 - `n_base4_digits::Int32`: number of base-4 digits for Morton encoding
 - `seed::UInt32`: scrambling seed
@@ -362,18 +346,12 @@ end
 
 Create a SobolRNG for the given render settings.
 Allocates Sobol matrices on the specified backend (CPU/GPU).
-
-# Arguments
-- `backend`: KernelAbstractions backend (e.g., `CPU()`, `CUDABackend()`, `OpenCLBackend()`)
-- `seed`: Scrambling seed for decorrelation
-- `width`: Image width in pixels
-- `height`: Image height in pixels
-- `samples_per_pixel`: Number of samples per pixel
 """
 function SobolRNG(backend, seed::UInt32, width::Integer, height::Integer, samples_per_pixel::Integer)
-    # Allocate and copy Sobol matrices to GPU
-    matrices = KA.allocate(backend, UInt32, length(SobolMatrices32))
-    KA.copyto!(backend, matrices, SobolMatrices32)
+    # Allocate and copy Sobol matrices + packed permutation table to GPU
+    combined = vcat(SobolMatrices32, PACKED_PERMUTATIONS_4WAY)
+    matrices = KA.allocate(backend, UInt32, length(combined))
+    KA.copyto!(backend, matrices, combined)
 
     # Compute ZSobol parameters
     log2_spp, n_base4_digits = compute_zsobol_params(Int(samples_per_pixel), Int(width), Int(height))

--- a/src/spectral/rgb2spec.jl
+++ b/src/spectral/rgb2spec.jl
@@ -68,10 +68,11 @@ Parameterized by array types for GPU compatibility:
 
 Use `to_gpu(ArrayType, table)` to convert to GPU-compatible arrays.
 """
-struct RGBToSpectrumTable{V1 <: AbstractVector{Float32}, V5 <: AbstractArray{Float32, 5}}
+struct RGBToSpectrumTable{V1 <: AbstractVector{Float32}, V5 <: AbstractArray{Float32, 5}, VD <: AbstractVector{Float32}}
     res::Int32
     scale::V1           # [res] - z-axis (max component) scale values
     coeffs::V5          # [3, res, res, res, 3] - [maxc, z, y, x, coeff]
+    d65_values::VD      # [107] - D65 illuminant values as GPU array (avoids NTuple runtime indexing on Metal)
 end
 
 """
@@ -394,7 +395,7 @@ rgb_illuminant_spectrum(table::RGBToSpectrumTable, rgb::RGB) =
 # ============================================================================
 
 # Type alias for CPU table
-const RGBToSpectrumTableCPU = RGBToSpectrumTable{Vector{Float32}, Array{Float32, 5}}
+const RGBToSpectrumTableCPU = RGBToSpectrumTable{Vector{Float32}, Array{Float32, 5}, Vector{Float32}}
 
 # Global table instance (loaded lazily) - always CPU version
 const _srgb_table = Ref{Union{Nothing, RGBToSpectrumTableCPU}}(nothing)
@@ -407,7 +408,7 @@ function load_srgb_table_binary(path::String)::RGBToSpectrumTableCPU
         read!(io, scale)
         coeffs = Array{Float32, 5}(undef, 3, res, res, res, 3)
         read!(io, coeffs)
-        return RGBToSpectrumTable(res, scale, coeffs)
+        return RGBToSpectrumTable(res, scale, coeffs, _d65_cpu_values())
     end
 end
 
@@ -432,7 +433,7 @@ function get_srgb_table()::RGBToSpectrumTableCPU
             println("Generating sRGB spectrum table (this may take a minute)...")
             include(joinpath(@__DIR__, "rgb2spec_gen.jl"))
             table_data = RGB2SpecGen.generate_rgb2spec_table(64; verbose=true)
-            table = RGBToSpectrumTable(Int32(table_data.res), table_data.scale, table_data.coeffs)
+            table = RGBToSpectrumTable(Int32(table_data.res), table_data.scale, table_data.coeffs, _d65_cpu_values())
             save_srgb_table_binary(bin_path, table)
             _srgb_table[] = table
         end
@@ -453,7 +454,8 @@ Uses KernelAbstractions backend for allocation.
 function to_gpu(backend, table::RGBToSpectrumTable)
     scale_gpu = adapt(backend, table.scale)
     coeffs_gpu = adapt(backend, table.coeffs)
-    return RGBToSpectrumTable(table.res, scale_gpu, coeffs_gpu)
+    d65_gpu = adapt(backend, table.d65_values)
+    return RGBToSpectrumTable(table.res, scale_gpu, coeffs_gpu, d65_gpu)
 end
 
 function Adapt.adapt_structure(to, table::RGBToSpectrumTable)
@@ -461,5 +463,6 @@ function Adapt.adapt_structure(to, table::RGBToSpectrumTable)
         table.res,
         Adapt.adapt(to, table.scale),
         Adapt.adapt(to, table.coeffs),
+        Adapt.adapt(to, table.d65_values),
     )
 end

--- a/src/spectral/uplift.jl
+++ b/src/spectral/uplift.jl
@@ -429,10 +429,21 @@ const D65_ILLUMINANT_VALUES = (
 )
 
 """
+    _d65_cpu_values() -> Vector{Float32}
+
+Return D65 illuminant values as a CPU Vector for use in RGBToSpectrumTable.
+This avoids runtime NTuple indexing which fails on Metal GPU.
+"""
+function _d65_cpu_values()::Vector{Float32}
+    return collect(Float32, D65_ILLUMINANT_VALUES)
+end
+
+"""
     sample_d65(lambda::Float32) -> Float32
 
 Sample the D65 illuminant spectrum at wavelength lambda (nm).
 Uses linear interpolation between tabulated values.
+CPU-only version using NTuple constant (not Metal-compatible).
 """
 @propagate_inbounds function sample_d65(lambda::Float32)::Float32
     # Clamp to valid range
@@ -457,6 +468,30 @@ Uses linear interpolation between tabulated values.
 end
 
 """
+    sample_d65(lambda::Float32, d65_values::AbstractVector{Float32}) -> Float32
+
+GPU-compatible version that reads from a GPU array instead of NTuple constant.
+Required for Metal where runtime NTuple indexing returns 0.
+"""
+@propagate_inbounds function sample_d65(lambda::Float32, d65_values::AbstractVector{Float32})::Float32
+    if lambda <= 300f0
+        return @inbounds d65_values[1]
+    elseif lambda >= 830f0
+        return @inbounds d65_values[107]
+    end
+
+    t = (lambda - 300f0) / 5f0
+    idx = floor_int32(t) + Int32(1)
+    idx = clamp(idx, Int32(1), Int32(106))
+    frac = t - Float32(floor_int32(t))
+    @inbounds begin
+        v0 = d65_values[idx]
+        v1 = d65_values[idx + Int32(1)]
+    end
+    return v0 * (1f0 - frac) + v1 * frac
+end
+
+"""
     sample_d65_spectral(lambda::Wavelengths) -> SpectralRadiance
 
 Sample D65 illuminant at multiple wavelengths.
@@ -471,6 +506,17 @@ Matches pbrt-v4's illuminant->Sample(lambda) behavior.
         v4 = sample_d65(lambda.lambda[4])
     end
     # Return raw D65 values matching pbrt-v4's DenselySampledSpectrum::Sample()
+    return SpectralRadiance((v1, v2, v3, v4))
+end
+
+"""GPU-compatible version using array instead of NTuple."""
+@propagate_inbounds function sample_d65_spectral(lambda::Wavelengths, d65_values::AbstractVector{Float32})::SpectralRadiance
+    @inbounds begin
+        v1 = sample_d65(lambda.lambda[1], d65_values)
+        v2 = sample_d65(lambda.lambda[2], d65_values)
+        v3 = sample_d65(lambda.lambda[3], d65_values)
+        v4 = sample_d65(lambda.lambda[4], d65_values)
+    end
     return SpectralRadiance((v1, v2, v3, v4))
 end
 
@@ -527,8 +573,9 @@ point is D65, so an RGB=(1,1,1) light source should emit a D65-like spectrum.
 
     # Sample polynomial at wavelengths and multiply by D65 illuminant
     # Following pbrt-v4's RGBIlluminantSpectrum::Sample()
+    # Use GPU array for D65 values (NTuple runtime indexing fails on Metal)
     @inbounds begin
-        d65 = sample_d65_spectral(lambda)
+        d65 = sample_d65_spectral(lambda, table.d65_values)
         v1 = scale * poly(lambda.lambda[1]) * d65.data[1]
         v2 = scale * poly(lambda.lambda[2]) * d65.data[2]
         v3 = scale * poly(lambda.lambda[3]) * d65.data[3]
@@ -559,10 +606,18 @@ Do NOT use for:
 end
 
 # RGBIlluminantSpectrum already has the polynomial baked in, just sample it
+# Uses table.d65_values for GPU-compatible D65 lookup
 @propagate_inbounds function uplift_rgb_illuminant(
-    ::RGBToSpectrumTable, s::RGBIlluminantSpectrum, lambda::Wavelengths
+    table::RGBToSpectrumTable, s::RGBIlluminantSpectrum, lambda::Wavelengths
 )::SpectralRadiance
-    return Sample(s, lambda)
+    @inbounds begin
+        d65 = sample_d65_spectral(lambda, table.d65_values)
+        v1 = s.scale * s.poly(lambda.lambda[1]) * d65.data[1]
+        v2 = s.scale * s.poly(lambda.lambda[2]) * d65.data[2]
+        v3 = s.scale * s.poly(lambda.lambda[3]) * d65.data[3]
+        v4 = s.scale * s.poly(lambda.lambda[4]) * d65.data[4]
+    end
+    return SpectralRadiance((v1, v2, v3, v4))
 end
 
 """
@@ -579,15 +634,22 @@ while RGBIlluminantSpectrum uses its baked-in polynomial.
 end
 
 """
-    Sample(::RGBToSpectrumTable, s::RGBIlluminantSpectrum, lambda::Wavelengths) -> SpectralRadiance
+    Sample(table::RGBToSpectrumTable, s::RGBIlluminantSpectrum, lambda::Wavelengths) -> SpectralRadiance
 
 Sample an RGBIlluminantSpectrum at multiple wavelengths.
-The table argument is ignored since the polynomial is already baked in.
+Uses table.d65_values for GPU-compatible D65 lookup.
 """
 @propagate_inbounds function Sample(
-    ::RGBToSpectrumTable, s::RGBIlluminantSpectrum, lambda::Wavelengths
+    table::RGBToSpectrumTable, s::RGBIlluminantSpectrum, lambda::Wavelengths
 )::SpectralRadiance
-    return Sample(s, lambda)
+    @inbounds begin
+        d65 = sample_d65_spectral(lambda, table.d65_values)
+        v1 = s.scale * s.poly(lambda.lambda[1]) * d65.data[1]
+        v2 = s.scale * s.poly(lambda.lambda[2]) * d65.data[2]
+        v3 = s.scale * s.poly(lambda.lambda[3]) * d65.data[3]
+        v4 = s.scale * s.poly(lambda.lambda[4]) * d65.data[4]
+    end
+    return SpectralRadiance((v1, v2, v3, v4))
 end
 
 # ============================================================================


### PR DESCRIPTION
## Summary

- **Sobol sampler**: Runtime NTuple indexing always returns 0 on Metal. Replace `PERMUTATIONS_4WAY` (nested NTuples) with bit-packed `UInt32` values appended to the Sobol matrices GPU array. Also replace `@nexprs` unrolled loops with regular `for` loops (the unrolled form causes Metal compiler crashes or miscompilation with non-constant kernel arguments).
- **D65 illuminant**: Same NTuple issue — the D65 spectrum was stored as `NTuple{107, Float32}` indexed at runtime. Add `d65_values` field to `RGBToSpectrumTable` as a GPU array, with GPU-compatible `sample_d65` overloads.

## How these changes were tested

- Isolated kernel test confirms CPU and Metal produce identical Sobol sample values
- CPU and Metal render of 3-sphere scene produce identical mean pixel values (~0.327)
- 20-material gallery scene (glass, volumetrics, metals, coated, emissive) renders correctly on Metal
- Tested at multiple sample counts (4, 8, 16, 32 spp)

Created with the help of [Claude Code](https://claude.com/claude-code)